### PR TITLE
Add problem instances for coarse set.

### DIFF
--- a/problem_instances/problem_instance.benzene.f377cc27-366a-45af-b45a-c8478e4b6199.json
+++ b/problem_instances/problem_instance.benzene.f377cc27-366a-45af-b45a-c8478e4b6199.json
@@ -1,0 +1,105 @@
+{
+    "problem_instance_uuid": "f377cc27-366a-45af-b45a-c8478e4b6199",
+    "$schema": "https://raw.githubusercontent.com/isi-usc-edu/qb-gsee-benchmark/main/schemas/problem_instance.schema.0.0.1.json",
+    "problem_type": "GSEE",
+    "application_domain": "QC",
+    "creation_timestamp": "2024-11-19T18:34:11.483879",
+    "calendar_due_date": "2124-10-26T18:34:11.484017",
+    "status": "in_force",
+    "superseded_by": null,
+    "contact_info": [
+        {
+            "name": "Matthew Otten",
+            "email": "mjotten@wisc.edu",
+            "institution": "University of Wisconsin -- Madison"
+        }
+    ],
+    "license": {
+        "name": "Apache 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "references": [
+        "The Journal of Physical Chemistry Letters 2020 11 (20), 8922-8929 DOI: 10.1021/acs.jpclett.0c02621"
+    ],
+    "instance_data": [
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Benzene",
+                "geometry": [
+                    "C 0.000000 1.396792 0.000000",
+                    "C 0.000000 -1.396792 0.000000",
+                    "C 1.209657 0.698396 0.000000",
+                    "C -1.209657 -0.698396 0.000000",
+                    "C -1.209657 0.698396 0.000000",
+                    "C 1.209657 -0.698396 0.000000",
+                    "H 0.000000 2.484212 0.000000",
+                    "H 2.151390 1.242106 0.000000",
+                    "H -2.151390 -1.242106 0.000000",
+                    "H -2.151390 1.242106 0.000000",
+                    "H 2.151390 -1.242106 0.000000",
+                    "H 0.000000 -2.484212 0.000000"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "4c655f65-1899-469c-975a-a3caec750697",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_benzene_sto-3g_4c655f65-1899-469c-975a-a3caec750697.gz",
+                    "instance_data_checksum": "358ab2639cdfa6195a760abf231e8b33c6681e27",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Benzene",
+                "geometry": [
+                    "C 0.000000 1.396792 0.000000",
+                    "C 0.000000 -1.396792 0.000000",
+                    "C 1.209657 0.698396 0.000000",
+                    "C -1.209657 -0.698396 0.000000",
+                    "C -1.209657 0.698396 0.000000",
+                    "C 1.209657 -0.698396 0.000000",
+                    "H 0.000000 2.484212 0.000000",
+                    "H 2.151390 1.242106 0.000000",
+                    "H -2.151390 -1.242106 0.000000",
+                    "H -2.151390 1.242106 0.000000",
+                    "H 2.151390 -1.242106 0.000000",
+                    "H 0.000000 -2.484212 0.000000"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "96ff0e22-a3ab-49f3-aee9-9a1886cbf850",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_benzene_cc-pvdz_96ff0e22-a3ab-49f3-aee9-9a1886cbf850.gz",
+                    "instance_data_checksum": "ce09c8ce0d2bd030c6e886c0e099a6d656f33edd",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        }
+    ],
+    "short_name": "benzene"
+}

--- a/problem_instances/problem_instance.cr_dimer.8ed1a800-a4c6-4bff-a6de-cb220554c42f.json
+++ b/problem_instances/problem_instance.cr_dimer.8ed1a800-a4c6-4bff-a6de-cb220554c42f.json
@@ -1,0 +1,387 @@
+{
+    "problem_instance_uuid": "8ed1a800-a4c6-4bff-a6de-cb220554c42f",
+    "$schema": "https://raw.githubusercontent.com/isi-usc-edu/qb-gsee-benchmark/main/schemas/problem_instance.schema.0.0.1.json",
+    "problem_type": "GSEE",
+    "application_domain": "QC",
+    "creation_timestamp": "2024-11-19T21:13:19.486613",
+    "calendar_due_date": "2124-10-26T21:13:19.486764",
+    "status": "in_force",
+    "superseded_by": null,
+    "contact_info": [
+        {
+            "name": "Matthew Otten",
+            "email": "mjotten@wisc.edu",
+            "institution": "University of Wisconsin -- Madison"
+        }
+    ],
+    "license": {
+        "name": "Apache 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "references": [
+        "Journal of the American Chemical Society 2022 144 (35), 15932-15937 DOI: 10.1021/jacs.2c06357"
+    ],
+    "instance_data": [
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 1.68"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "3092dd74-660d-4c7a-9d43-16d1436e084b",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_1.68_b_sto-3g_ne_12.3092dd74-660d-4c7a-9d43-16d1436e084b.gz",
+                    "instance_data_checksum": "7d79d6618ff311cf5c844691276db4ea75d2902d",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 1.68"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "96843098-e69d-4d1f-8a88-5b24826f7390",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_1.68_b_sto-3g_ne_28.96843098-e69d-4d1f-8a88-5b24826f7390.gz",
+                    "instance_data_checksum": "6763701f533702a4032fa9c9d218d3921432b515",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 1.68"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "673dfe91-d90e-4ecd-8560-d6d74de11070",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_1.68_b_cc-pvdz-dk_ne_12.673dfe91-d90e-4ecd-8560-d6d74de11070.gz",
+                    "instance_data_checksum": "bee1eab1b5bf68f5f2a71eefd85b2892e4b19d7a",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 1.68"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "4412b7d6-86db-4616-9dd2-2c32ee02560f",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_1.68_b_cc-pvdz-dk_ne_28.4412b7d6-86db-4616-9dd2-2c32ee02560f.gz",
+                    "instance_data_checksum": "5a416e50c8416cb875537ace6a0d17e83c746807",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 2.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "cdf017c4-7c30-4274-9567-f5e55a6ba857",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_2.0_b_sto-3g_ne_12.cdf017c4-7c30-4274-9567-f5e55a6ba857.gz",
+                    "instance_data_checksum": "edef00cb9132faa896aa2d5aa866318e336dbc8b",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 2.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "d9341cde-90e8-4d1e-beb2-4e40246d31ce",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_2.0_b_sto-3g_ne_28.d9341cde-90e8-4d1e-beb2-4e40246d31ce.gz",
+                    "instance_data_checksum": "7a05834e93505385fbe3d54346a34b528c4f278a",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 2.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "5439a548-153b-4990-be12-f0e33c30fe63",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_2.0_b_cc-pvdz-dk_ne_12.5439a548-153b-4990-be12-f0e33c30fe63.gz",
+                    "instance_data_checksum": "31b8feff3869ca126fe7677a26a8530ed4065ca1",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 2.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "e2995852-9911-4021-a82f-5b14ddb2d5c8",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_2.0_b_cc-pvdz-dk_ne_28.e2995852-9911-4021-a82f-5b14ddb2d5c8.gz",
+                    "instance_data_checksum": "e572a3c560a67dd3ba8f760cb9d7cb3305cdd649",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 3.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "67acc90d-1a9e-49a7-98a1-8ca643dca272",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_3.0_b_sto-3g_ne_12.67acc90d-1a9e-49a7-98a1-8ca643dca272.gz",
+                    "instance_data_checksum": "ab8dd5eb992bc45c3158e62fda5b729108e6eda2",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 3.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "01d526fb-276e-4369-85d4-66a553a1d02e",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_3.0_b_sto-3g_ne_28.01d526fb-276e-4369-85d4-66a553a1d02e.gz",
+                    "instance_data_checksum": "33217b4ea3941b07f3a162144a293a1a2abb9ca5",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 3.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 12
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "b0eb2de4-1286-4cfb-8724-e5e4bfc7a4f4",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_3.0_b_cc-pvdz-dk_ne_12.b0eb2de4-1286-4cfb-8724-e5e4bfc7a4f4.gz",
+                    "instance_data_checksum": "cb061a473439bd67f2040938188a810eb5483e6d",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "Cr Dimer",
+                "geometry": [
+                    "Cr 0 0 0",
+                    "Cr 0 0 3.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz-dk"
+                },
+                "charge": 0,
+                "utility_scale": false,
+                "correlated_electrons": 28
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "2101e6fa-9fb3-4697-98be-25a4e0de2079",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_d_3.0_b_cc-pvdz-dk_ne_28.2101e6fa-9fb3-4697-98be-25a4e0de2079.gz",
+                    "instance_data_checksum": "4eacce4787d99756904434a2e683d0a3cac190b5",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        }
+    ],
+    "short_name": "cr_dimer"
+}

--- a/problem_instances/problem_instance.ozone.9560107e-f1ad-4480-aa51-ef03edda6e19.json
+++ b/problem_instances/problem_instance.ozone.9560107e-f1ad-4480-aa51-ef03edda6e19.json
@@ -1,0 +1,207 @@
+{
+    "problem_instance_uuid": "9560107e-f1ad-4480-aa51-ef03edda6e19",
+    "$schema": "https://raw.githubusercontent.com/isi-usc-edu/qb-gsee-benchmark/main/schemas/problem_instance.schema.0.0.1.json",
+    "problem_type": "GSEE",
+    "application_domain": "QC",
+    "creation_timestamp": "2024-11-19T22:09:15.519174",
+    "calendar_due_date": "2124-10-26T22:09:15.519272",
+    "status": "in_force",
+    "superseded_by": null,
+    "contact_info": [
+        {
+            "name": "Matthew Otten",
+            "email": "mjotten@wisc.edu",
+            "institution": "University of Wisconsin -- Madison"
+        }
+    ],
+    "license": {
+        "name": "Apache 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "references": [
+        "The Journal of Physical Chemistry A 2018 122 (10), 2714-2722 DOI: 10.1021/acs.jpca.8b01554"
+    ],
+    "instance_data": [
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Ring",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.465 0.0 0.0",
+                    "O 0.7347132299386051 1.2674468311346172 0.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "b0c72570-cf06-4ecc-ae64-52a65720c849",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_ring_b_cc-pvdz.b0c72570-cf06-4ecc-ae64-52a65720c849.gz",
+                    "instance_data_checksum": "f320da15a25daabc0d935e37435c993a49afa0d4",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Ring",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.465 0.0 0.0",
+                    "O 0.7347132299386051 1.2674468311346172 0.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "598f7475-c056-4a46-8d20-5159c73e5d02",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_ring_b_sto-3g.598f7475-c056-4a46-8d20-5159c73e5d02.gz",
+                    "instance_data_checksum": "a04bafa04bbb6a22306d9ec0c865c7c7b654c73b",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Ring",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.465 0.0 0.0",
+                    "O 0.7347132299386051 1.2674468311346172 0.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvtz"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "8fc9b179-ff7d-4402-b0cf-18ec074b211a",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_ring_b_cc-pvtz.8fc9b179-ff7d-4402-b0cf-18ec074b211a.gz",
+                    "instance_data_checksum": "08ecd91296825056c781cba52a8e17cd30bb61e9",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Bent",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.288 0.0 0.0",
+                    "O -0.5767137051363352 1.1516706570491062 0.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvdz"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "1a42101c-3c00-4105-8ed3-9275bf0d18db",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_bent_b_cc-pvdz.1a42101c-3c00-4105-8ed3-9275bf0d18db.gz",
+                    "instance_data_checksum": "381c3f19f4728ec746c2033efa92c132e646b1b3",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Bent",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.288 0.0 0.0",
+                    "O -0.5767137051363352 1.1516706570491062 0.0"
+                ],
+                "basis_set": {
+                    "default": "sto-3g"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "93698b08-3188-4961-b551-50ac2c1e62b3",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_bent_b_sto-3g.93698b08-3188-4961-b551-50ac2c1e62b3.gz",
+                    "instance_data_checksum": "ea2e42f65ac984f5e848fc0ad037aa2388fb2dde",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        },
+        {
+            "features": {
+                "software_used": "PySCF 2.5.0",
+                "molecule_name": "O3 Bent",
+                "geometry": [
+                    "O 0.0 0.0 0.0",
+                    "O 1.288 0.0 0.0",
+                    "O -0.5767137051363352 1.1516706570491062 0.0"
+                ],
+                "basis_set": {
+                    "default": "cc-pvtz"
+                },
+                "charge": 0,
+                "utility_scale": false
+            },
+            "requirements": {
+                "probability_of_success": 0.99,
+                "time_limit_seconds": 172800,
+                "accuracy": 1.0,
+                "energy_units": "millihartree"
+            },
+            "supporting_files": [
+                {
+                    "instance_data_object_uuid": "8b6ad6f7-f004-4941-95b2-829eb3723c8d",
+                    "instance_data_object_url": "sftp://sftp.l3harris.com/gsee/FCIDUMP_g_bent_b_cc-pvtz.8b6ad6f7-f004-4941-95b2-829eb3723c8d.gz",
+                    "instance_data_checksum": "5276be9b9bd5d861b8dec87f5921ec3a9accb269",
+                    "instance_data_checksum_type": "sha1sum"
+                }
+            ]
+        }
+    ],
+    "short_name": "ozone"
+}


### PR DESCRIPTION
I've added the problem instance files for the O3, Benzene, and Cr2. Mn_mono seems to already be included in the problem_instances. The FermiHubbard coarse set instances are not included here because I plan to include the ones from the V-Score paper, which have more sophisticated exact energy references.

I see I missed a lot of reorganizing today, so this may need to be changed somewhat?