### PR TITLE
Fixes to schemas and problem instances

### DIFF
--- a/schemas/problem_instance.schema.0.0.1.json
+++ b/schemas/problem_instance.schema.0.0.1.json
@@ -10,7 +10,7 @@
         "calendar_due_date",
         "contact_info",
         "problem_type",
-        "instance_data",
+        "tasks",
         "status",
         "superseded_by",
         "application_domain",

--- a/schemas/solution.schema.0.0.1.json
+++ b/schemas/solution.schema.0.0.1.json
@@ -123,13 +123,13 @@
                     "classical_resources": {
                         "title": "Classical Resources",
                         "description": "Required classical compute resources. Values defined here are considered to override those of solver_details where conflict exists.",
-                        "type": "object"
+                        "type": "object",
                          "properties" : {
                             "ram_used_gb" : {
                                 "title": "RAM (GB)",
                                 "description": "Total RAM available for the computation, in GB.",
                                 "type": "number"
-                            },
+                            }
                         }
                     },
                     "quantum_resources": {
@@ -185,9 +185,6 @@
                         "title": "Wall Clock Runtime",
                         "description": "A breakdown of start/stop wall clock time(s) reported according to ISO 8601 in UTC and duration in seconds.  run_time is broken down into (1) overall_time, (2) preprocessing_time, (3), algorithm_run_time, and (4) postprocessing_time.  See descriptions of each object.",
                         "type": "object",
-                        "required": [
-                            "overall_time"
-                        ],
                         "properties": {
                             "overall_time": {
                                 "title": "Overall Wall Clock Time",
@@ -337,7 +334,7 @@
             "classical_hardware_details": {
                 "title": "Classical Compute Hardware Details",
                 "description": "Details on the hardware used by the solver. All tasks are assumed to have the included values unless specified otherwise at the task level.",
-                "type": "object"
+                "type": "object",
                  "properties" : {
                     "cpu_description" : {
                         "title": "CPU Description",
@@ -363,7 +360,7 @@
                         "title": "Computing Environment Name",
                         "description": "Identifying name of computing environment (e.g. cluster or facility name), if relevant.",
                         "type": "string"
-                    },
+                    }
                 }
                     
             },
@@ -421,13 +418,14 @@
             "solution_data": {
                 "items": {
                     "required": ["energy"],
-                    "properties" : {
-                        "runtime" : {
-                            "required" : "overall_time"
+                    "properties": {
+                        "run_time": {
+                            "required": ["overall_time"]
                         }
                     }
                 }
             }
         }
     }
+
 }


### PR DESCRIPTION
This PR fixes a few mistakes in the solution schema and also updates the problem instances that were removed by CI in the last commit to comply with the new schemas. Note that each task has been assigned a new UUID that differs from the fcidump UUIDs, as discussed in https://github.com/isi-usc-edu/qb-gsee-benchmark/pull/14.