### PR TITLE
Fixes to LRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Contact the repository maintainers to get these.
 ### Generating Logical Quantum Resource Estimates
 
 The [`scripts/compute_all_LREs_script.py`](scripts/compute_all_LREs_script.py) script can be used to generate LQREs.
-In order to run this script, two files are required:
+In order to run this script, first ensure that the qb-gsee-benchmark package is installed as described above.
+Then, two additional files are required:
 
 * A PPK file containing a key to access the SFTP server that provides access to FCIDUMP files as described above.
 * A configuration file similar to [`scripts/LRE_config.json`](scripts/LRE_config.json) which specifies algorithm parameters, solver UUID, and other information.

--- a/schemas/solution.schema.0.0.1.json
+++ b/schemas/solution.schema.0.0.1.json
@@ -178,9 +178,6 @@
                         "title": "Wall Clock Runtime",
                         "description": "A breakdown of start/stop wall clock time(s) reported according to ISO 8601 in UTC and duration in seconds.  run_time is broken down into (1) overall_time, (2) preprocessing_time, (3), algorithm_run_time, and (4) postprocessing_time.  See descriptions of each object.",
                         "type": "object",
-                        "required": [
-                            "overall_time"
-                        ],
                         "properties": {
                             "overall_time": {
                                 "title": "Overall Wall Clock Time",
@@ -421,7 +418,7 @@
             "solution_data": {
                 "items": {
                     "required": [
-                        "energy"
+                        "energy", "run_time"
                     ],
                     "properties": {
                         "run_time": {

--- a/scripts/compute_all_LREs_script.py
+++ b/scripts/compute_all_LREs_script.py
@@ -22,7 +22,6 @@ import logging
 import math
 import os
 import sys
-from datetime import UTC
 from importlib.metadata import version
 from typing import Any
 from urllib.parse import urlparse
@@ -163,7 +162,7 @@ def get_lqre(
             )
 
     solution_uuid = str(uuid4())
-    current_time = datetime.datetime.now(UTC)
+    current_time = datetime.datetime.now(datetime.timezone.utc)
     current_time_string = current_time.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
 
     solver_details = {

--- a/src/qb_gsee_benchmark/qre.py
+++ b/src/qb_gsee_benchmark/qre.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 from openfermion import InteractionOperator
-from openfermion.resource_estimates.molecule import cas_to_pyscf
 from pyLIQTR.BlockEncodings.DoubleFactorized import DoubleFactorized
 from pyLIQTR.ProblemInstances.ChemicalHamiltonian import ChemicalHamiltonian
 from pyLIQTR.qubitization.phase_estimation import QubitizedPhaseEstimation


### PR DESCRIPTION
This PR addresses a few issues @jp7745 described in https://github.com/isi-usc-edu/qb-gsee-benchmark/pull/37#issuecomment-2515250995.
* Removed unused openfermion import.
* Removed use of `datetime.UTC` alias, which is not available in older versions of datetime.
* Updated solution schema to make `overall_time` an optional field of `run_time` for resource estimates, and `run_time` a required field for actual solutions.
* Updated readme to be more explicit about installing dependencies.