### PR TITLE
Ensure all planted solutions problem instances have `utility_scale` set to false.

### DIFF
--- a/problem_instances/problem_instance.planted_solution_0002.00043d56-ed63-4266-907c-99c95c51b9db.json
+++ b/problem_instances/problem_instance.planted_solution_0002.00043d56-ed63-4266-907c-99c95c51b9db.json
@@ -45,7 +45,7 @@
         "multiplicity": 1,
         "num_electrons": 90,
         "num_orbitals": 69,
-        "utility_scale": true
+        "utility_scale": false
       },
       "task_uuid": "0deae366-42de-4081-914d-db85c6b47168"
     }

--- a/problem_instances/problem_instance.planted_solution_0004.e0adafc5-789e-43e6-8f9e-e718da28de3a.json
+++ b/problem_instances/problem_instance.planted_solution_0004.e0adafc5-789e-43e6-8f9e-e718da28de3a.json
@@ -45,7 +45,7 @@
         "multiplicity": 1,
         "num_electrons": 90,
         "num_orbitals": 70,
-        "utility_scale": true
+        "utility_scale": false
       },
       "task_uuid": "c9809448-2f3d-40d4-858d-6288a4703af4"
     }

--- a/problem_instances/problem_instance.planted_solution_0009.8db449b1-265b-4a66-b965-a2b4833a88d1.json
+++ b/problem_instances/problem_instance.planted_solution_0009.8db449b1-265b-4a66-b965-a2b4833a88d1.json
@@ -45,7 +45,7 @@
         "multiplicity": 1,
         "num_electrons": 90,
         "num_orbitals": 69,
-        "utility_scale": true
+        "utility_scale": false
       },
       "task_uuid": "8f373cb0-952d-48c6-a871-8a10e52e7c19"
     }


### PR DESCRIPTION
Previously, some were set to true based on the problem size. Given discussions during meetings, this seems to not be the intent of the `utility_scale` flag. As all planted solutions have no direct utility, even if the number of orbitals is comparable to utility-possessing problems, the flag is set to false.