### PR TITLE
Exposing sf threshold as algorithm parameter

### DIFF
--- a/scripts/LRE_config.json
+++ b/scripts/LRE_config.json
@@ -2,6 +2,7 @@
   "solver_uuid": "c60803ef-14a4-4423-9ebe-31b643d8e42b",
   "algorithm_parameters": {
     "overlap": 0.8,
+    "sf_threshold": 1e-8,
     "df_threshold": 1e-3,
     "max_orbitals": 32
   },

--- a/scripts/LRE_config.json
+++ b/scripts/LRE_config.json
@@ -2,7 +2,7 @@
   "solver_uuid": "c60803ef-14a4-4423-9ebe-31b643d8e42b",
   "algorithm_parameters": {
     "overlap": 0.8,
-    "sf_threshold": 1e-8,
+    "sf_threshold": 1e-12,
     "df_threshold": 1e-3,
     "max_orbitals": 32
   },

--- a/scripts/LRE_config_overlaps.json
+++ b/scripts/LRE_config_overlaps.json
@@ -2,6 +2,7 @@
   "solver_uuid": "f2d73e1f-3058-43c4-a634-b6c267c84ff1",
   "algorithm_parameters": {
     "overlap_csv": "overlaps.csv",
+    "sf_threshold": 1e-8,
     "df_threshold": 1e-3,
     "max_orbitals": 32
   },

--- a/scripts/LRE_config_overlaps.json
+++ b/scripts/LRE_config_overlaps.json
@@ -2,7 +2,7 @@
   "solver_uuid": "f2d73e1f-3058-43c4-a634-b6c267c84ff1",
   "algorithm_parameters": {
     "overlap_csv": "overlaps.csv",
-    "sf_threshold": 1e-8,
+    "sf_threshold": 1e-12,
     "df_threshold": 1e-3,
     "max_orbitals": 32
   },

--- a/scripts/compute_all_LREs_script.py
+++ b/scripts/compute_all_LREs_script.py
@@ -22,7 +22,6 @@ import logging
 import math
 import os
 import sys
-from collections import defaultdict
 from importlib.metadata import version
 from typing import Any
 from urllib.parse import urlparse
@@ -143,6 +142,7 @@ def get_lqre(
                 error_tolerance=error_tolerance,
                 failure_tolerance=failure_tolerance,
                 square_overlap=overlap**2,
+                sf_threshold=config["algorithm_parameters"]["sf_threshold"],
                 df_threshold=config["algorithm_parameters"]["df_threshold"],
             )
             circuit_generation_end_time = datetime.datetime.now()

--- a/src/qb_gsee_benchmark/qre.py
+++ b/src/qb_gsee_benchmark/qre.py
@@ -75,6 +75,7 @@ def get_df_qpe_circuit(
     square_overlap: float,
     error_tolerance: float,
     failure_tolerance: float,
+    sf_threshold: float,
     df_threshold: float,
 ):
     """Get the QPE circuit for a given PySCF FCI object.
@@ -152,7 +153,7 @@ def get_df_qpe_circuit(
         instance,
         energy_error=block_encoding_error_tolerance * 10 * 2 / 3,
         df_error_threshold=df_threshold,
-        sf_error_threshold=1e-12,  # See https://github.com/isi-usc-edu/pyLIQTR/issues/21
+        sf_error_threshold=sf_threshold,  # See https://github.com/isi-usc-edu/pyLIQTR/issues/21
     )
 
     circuit = QubitizedPhaseEstimation(encoding, eps=sigma)

--- a/tests/qb_gsee_benchmark/test_qre.py
+++ b/tests/qb_gsee_benchmark/test_qre.py
@@ -63,6 +63,6 @@ def test_get_df_qpe_circuit():
         error_tolerance=error_tolerance,
         failure_tolerance=failure_tolerance,
         df_threshold=1e-3,
-        sf_error_threshold=1e-8,
+        sf_error_threshold=1e-12,
     )
     assert (1 - square_overlap) ** num_shots < failure_tolerance

--- a/tests/qb_gsee_benchmark/test_qre.py
+++ b/tests/qb_gsee_benchmark/test_qre.py
@@ -63,5 +63,6 @@ def test_get_df_qpe_circuit():
         error_tolerance=error_tolerance,
         failure_tolerance=failure_tolerance,
         df_threshold=1e-3,
+        sf_error_threshold=1e-8,
     )
     assert (1 - square_overlap) ** num_shots < failure_tolerance


### PR DESCRIPTION
Right now, the single-factorization threshold used by the LRE script is not configurable and also is not recorded in the solution files. This PR addresses this by exposing this value as an algorithm parameter in the LRE config file, which in turn is saved in the solver_details section of the solution file. The example LRE config files are updated to set this to 1e-12, the same value that was previously hard-coded.