### PR TITLE
update resource estimates to EXCLUDE logical-compiled and physical

### DIFF
--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cr_0.54_orbitals.5d85532e-9116-48a1-9810-7925c9ed9c57.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cr_0.54_orbitals.5d85532e-9116-48a1-9810-7925c9ed9c57.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 323909060720
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 6055231.181249,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cr_1.54_orbitals.b24b71b9-971a-4aca-9fc0-7198d16ca9ed.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cr_1.54_orbitals.b24b71b9-971a-4aca-9fc0-7198d16ca9ed.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 315828734064
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 5903212.758298,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cu_0.54_orbitals.7f0518e8-e2c8-4912-8268-4de4cd504084.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cu_0.54_orbitals.7f0518e8-e2c8-4912-8268-4de4cd504084.json
@@ -19,20 +19,5 @@
         "num_qubits": 1792,
         "t_count": 1014336850272
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2688,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 18956844.471942,
-        "num_qubits": 2649088,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cu_1.54_orbitals.5f5fee92-5821-4d38-a54a-d204660f205f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Cu_1.54_orbitals.5f5fee92-5821-4d38-a54a-d204660f205f.json
@@ -19,20 +19,5 @@
         "num_qubits": 1790,
         "t_count": 245556316272
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2685,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4590196.263592,
-        "num_qubits": 2198410,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Fe_0.54_orbitals.5b8f4746-a08b-4ec5-92e2-ce55cc2fdb75.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Fe_0.54_orbitals.5b8f4746-a08b-4ec5-92e2-ce55cc2fdb75.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 362544892016
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 6776827.617965001,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Fe_1.54_orbitals.a7e26b10-bd6b-457c-978e-9050f6529007.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Fe_1.54_orbitals.a7e26b10-bd6b-457c-978e-9050f6529007.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 352593905776
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 6590492.351621999,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Mn_0.54_orbitals.289f5dfe-e6d5-48a3-a6ae-25088321d3c6.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Mn_0.54_orbitals.289f5dfe-e6d5-48a3-a6ae-25088321d3c6.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 350270261360
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 6547041.559696999,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Mn_1.54_orbitals.9d82f7d4-165d-4499-8add-361a770d1d44.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Mn_1.54_orbitals.9d82f7d4-165d-4499-8add-361a770d1d44.json
@@ -19,20 +19,5 @@
         "num_qubits": 1734,
         "t_count": 148560021496
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2601,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2294877.227481,
-        "num_qubits": 2076322,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_0.22_orbitals.402d5237-16a3-4eb8-8bd4-5dcf2cb14c36.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_0.22_orbitals.402d5237-16a3-4eb8-8bd4-5dcf2cb14c36.json
@@ -19,20 +19,5 @@
         "num_qubits": 715,
         "t_count": 3995567520
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1072,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 61713.796383999994,
-        "num_qubits": 802210,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_0.45_orbitals.85a3a8d6-f2c7-458c-bbc3-25fd76d9afc0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_0.45_orbitals.85a3a8d6-f2c7-458c-bbc3-25fd76d9afc0.json
@@ -19,20 +19,5 @@
         "num_qubits": 1470,
         "t_count": 129007093872
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2205,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2411295.7923330003,
-        "num_qubits": 1851850,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_1.22_orbitals.752966e5-7de7-4506-82ae-6b22cd54b1c1.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_1.22_orbitals.752966e5-7de7-4506-82ae-6b22cd54b1c1.json
@@ -19,20 +19,5 @@
         "num_qubits": 715,
         "t_count": 4116415904
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1072,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 63587.188644999995,
-        "num_qubits": 802210,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_1.45_orbitals.f9bdbb3b-91b6-43f3-93ca-bef1e10d3835.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.O_1.45_orbitals.f9bdbb3b-91b6-43f3-93ca-bef1e10d3835.json
@@ -19,20 +19,5 @@
         "num_qubits": 1472,
         "t_count": 73244477432
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2208,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1131383.8645829998,
-        "num_qubits": 1776192,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Sc_0.54_orbitals.fb87d637-aaab-4e8f-8898-4ecca8bd0fe0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Sc_0.54_orbitals.fb87d637-aaab-4e8f-8898-4ecca8bd0fe0.json
@@ -19,20 +19,5 @@
         "num_qubits": 1732,
         "t_count": 227955968112
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2598,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4260973.064608,
-        "num_qubits": 2135596,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Sc_1.54_orbitals.ca6f7678-0952-4fe4-83fe-c4455a682132.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Sc_1.54_orbitals.ca6f7678-0952-4fe4-83fe-c4455a682132.json
@@ -19,20 +19,5 @@
         "num_qubits": 1732,
         "t_count": 231531612272
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2598,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4327713.296678999,
-        "num_qubits": 2135596,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Ti_0.54_orbitals.ab61c91a-68ea-401f-a3ad-392e83ee802e.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Ti_0.54_orbitals.ab61c91a-68ea-401f-a3ad-392e83ee802e.json
@@ -19,20 +19,5 @@
         "num_qubits": 1737,
         "t_count": 1400250567008
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2605,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 26168558.008835,
-        "num_qubits": 2576764,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Ti_1.54_orbitals.2cd76a23-0514-458a-b588-94e2d10564d3.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.Ti_1.54_orbitals.2cd76a23-0514-458a-b588-94e2d10564d3.json
@@ -19,20 +19,5 @@
         "num_qubits": 1735,
         "t_count": 350293330032
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2602,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 6547470.146287001,
-        "num_qubits": 2139206,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.V_0.54_orbitals.0f0c8766-4bf5-4c1e-991a-9dafe9bc8f27.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.V_0.54_orbitals.0f0c8766-4bf5-4c1e-991a-9dafe9bc8f27.json
@@ -19,20 +19,5 @@
         "num_qubits": 1736,
         "t_count": 672883280104
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2604,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 12576022.72562,
-        "num_qubits": 2575000,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.V_1.54_orbitals.6d0f8edd-507f-43d5-9960-9ad49532ee42.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.V_1.54_orbitals.6d0f8edd-507f-43d5-9960-9ad49532ee42.json
@@ -19,20 +19,5 @@
         "num_qubits": 1736,
         "t_count": 559825815784
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2604,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 10463140.73969,
-        "num_qubits": 2556568,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.be_0.30_orbitals.543e2ed4-a12d-495b-a246-1e4d905ad4a3.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.be_0.30_orbitals.543e2ed4-a12d-495b-a246-1e4d905ad4a3.json
@@ -19,20 +19,5 @@
         "num_qubits": 961,
         "t_count": 14775813760
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1441,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 228227.46169400003,
-        "num_qubits": 1015492,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.be_0.55_orbitals.afdc2f74-eb52-41ae-b72a-30e5a4c07013.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.be_0.55_orbitals.afdc2f74-eb52-41ae-b72a-30e5a4c07013.json
@@ -19,20 +19,5 @@
         "num_qubits": 1766,
         "t_count": 290167982192
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2649,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 5424029.829384,
-        "num_qubits": 2172418,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.benzene.30_orbitals.b86457a4-abf4-43c9-9c08-2397e95b7c0f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.benzene.30_orbitals.b86457a4-abf4-43c9-9c08-2397e95b7c0f.json
@@ -19,20 +19,5 @@
         "num_qubits": 933,
         "t_count": 160080332728
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1399,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 2991602.9063999997,
-        "num_qubits": 1513072,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.18_orbitals.950da653-13ce-4cd7-95d8-5045ab03d4bc.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.18_orbitals.950da653-13ce-4cd7-95d8-5045ab03d4bc.json
@@ -19,20 +19,5 @@
         "num_qubits": 549,
         "t_count": 3840902560
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 823,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 59324.126711,
-        "num_qubits": 658288,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.4902741530427706e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.18_orbitals.9da97ef6-4bad-4c82-8576-9b8e539a7ba8.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.18_orbitals.9da97ef6-4bad-4c82-8576-9b8e539a7ba8.json
@@ -19,20 +19,5 @@
         "num_qubits": 548,
         "t_count": 1916519744
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 822,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 29615.466316,
-        "num_qubits": 657132,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.5855140598019322e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.19_orbitals.1a013e9f-7eab-4a1b-b486-1d9e2d99e754.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.19_orbitals.1a013e9f-7eab-4a1b-b486-1d9e2d99e754.json
@@ -19,20 +19,5 @@
         "num_qubits": 591,
         "t_count": 4358505888
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 886,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 67321.78819800001,
-        "num_qubits": 694702,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.2725814086361513e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.22_orbitals.13821f5c-78a6-485c-9006-a17a234cde9f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.22_orbitals.13821f5c-78a6-485c-9006-a17a234cde9f.json
@@ -19,20 +19,5 @@
         "num_qubits": 669,
         "t_count": 12539069952
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1003,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 234387.875864,
-        "num_qubits": 984728,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.7445006122518945e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.22_orbitals.f20db1b1-86e3-4ddf-96ff-a6d37f331935.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.22_orbitals.f20db1b1-86e3-4ddf-96ff-a6d37f331935.json
@@ -19,20 +19,5 @@
         "num_qubits": 668,
         "t_count": 6263506336
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1002,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 96759.923116,
-        "num_qubits": 761172,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 9.171294061182931e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.28_orbitals.001a0d11-165a-49c5-a334-643023029f40.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.28_orbitals.001a0d11-165a-49c5-a334-643023029f40.json
@@ -19,20 +19,5 @@
         "num_qubits": 846,
         "t_count": 23530899072
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1269,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 363418.657089,
-        "num_qubits": 1114618,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.3603124382526394e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.1c9508e3-b9fe-44f1-ae58-c6339ef43f47.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.1c9508e3-b9fe-44f1-ae58-c6339ef43f47.json
@@ -19,20 +19,5 @@
         "num_qubits": 1041,
         "t_count": 80542042104
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1561,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1505508.820898,
-        "num_qubits": 1387604,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 6.844917271497707e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.742be33c-0982-4b06-b324-1d86242e28d9.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.742be33c-0982-4b06-b324-1d86242e28d9.json
@@ -19,20 +19,5 @@
         "num_qubits": 1042,
         "t_count": 161505609840
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1563,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 3018503.616514,
-        "num_qubits": 1638406,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.280655523391926e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.765594e5-44ac-41a2-89a7-f2ac03536379.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.34_orbitals.765594e5-44ac-41a2-89a7-f2ac03536379.json
@@ -19,20 +19,5 @@
         "num_qubits": 1042,
         "t_count": 158320035952
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1563,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 2958961.770323,
-        "num_qubits": 1638406,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 7.146804381448915e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.3b49563d-948a-4ecb-84a0-d3c0c2c0d217.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.3b49563d-948a-4ecb-84a0-d3c0c2c0d217.json
@@ -19,20 +19,5 @@
         "num_qubits": 1094,
         "t_count": 187860519024
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1641,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 3511121.2856980003,
-        "num_qubits": 1725634,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.398467314526372e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.6713517a-ab65-4381-aae1-0839dcd6c1a0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.6713517a-ab65-4381-aae1-0839dcd6c1a0.json
@@ -19,20 +19,5 @@
         "num_qubits": 1093,
         "t_count": 94735566840
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1639,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1770842.9807670002,
-        "num_qubits": 1443920,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 8.909511557173511e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.858b9683-fc6c-4ebe-8c33-27f0d848f24f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.blue_dimer.36_orbitals.858b9683-fc6c-4ebe-8c33-27f0d848f24f.json
@@ -19,20 +19,5 @@
         "num_qubits": 1094,
         "t_count": 186566576240
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1641,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 3486932.3597109998,
-        "num_qubits": 1725634,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 8.737794553201076e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h2_0.38_orbitals.2761e36e-f001-42af-8086-f507b5643ec8.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h2_0.38_orbitals.2761e36e-f001-42af-8086-f507b5643ec8.json
@@ -19,20 +19,5 @@
         "num_qubits": 1222,
         "t_count": 50116822896
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1833,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 936793.4014920001,
-        "num_qubits": 1583266,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h4_0.48_orbitals.26423f2e-e3e1-4bbb-b2ff-52bdae87d65b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h4_0.48_orbitals.26423f2e-e3e1-4bbb-b2ff-52bdae87d65b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1510,
         "t_count": 227974842480
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2265,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4260938.3069939995,
-        "num_qubits": 1895170,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h6_0.58_orbitals.15a25e30-cba9-4f63-80a6-ef95a8c79d41.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c2_h6_0.58_orbitals.15a25e30-cba9-4f63-80a6-ef95a8c79d41.json
@@ -19,20 +19,5 @@
         "num_qubits": 1854,
         "t_count": 519118784768
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2781,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 9703259.582003998,
-        "num_qubits": 2267722,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h2_singlet_0.24_orbitals.5f0ac7ac-1dcc-46a6-bfa0-6e76c73a0bdd.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h2_singlet_0.24_orbitals.5f0ac7ac-1dcc-46a6-bfa0-6e76c73a0bdd.json
@@ -19,20 +19,5 @@
         "num_qubits": 771,
         "t_count": 11250763392
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1156,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 173731.00898699998,
-        "num_qubits": 850762,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h2_singlet_0.58_orbitals.8fa0ddcf-9b98-4144-8250-522f38c28b02.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h2_singlet_0.58_orbitals.8fa0ddcf-9b98-4144-8250-522f38c28b02.json
@@ -19,20 +19,5 @@
         "num_qubits": 1913,
         "t_count": 382867867904
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2869,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 7156453.193287,
-        "num_qubits": 2331980,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h3_cl_0.47_orbitals.0667179a-19eb-44b9-a544-dae8793fdc3f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h3_cl_0.47_orbitals.0667179a-19eb-44b9-a544-dae8793fdc3f.json
@@ -19,20 +19,5 @@
         "num_qubits": 1483,
         "t_count": 274471848048
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2224,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 5130335.070489,
-        "num_qubits": 1866290,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h4_0.34_orbitals.443371ce-c80d-450d-b281-ac1c4d5ecc4d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_h4_0.34_orbitals.443371ce-c80d-450d-b281-ac1c4d5ecc4d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1074,
         "t_count": 64017794928
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1611,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1196642.112083,
-        "num_qubits": 1422982,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o2_0.42_orbitals.615c9d78-2b84-4c7b-ab6b-ba05b188f50a.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o2_0.42_orbitals.615c9d78-2b84-4c7b-ab6b-ba05b188f50a.json
@@ -19,20 +19,5 @@
         "num_qubits": 1340,
         "t_count": 260671277288
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2010,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 4871704.881500999,
-        "num_qubits": 2032660,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o_0.28_orbitals.02588640-a5ae-48e6-b28b-f6759886ab70.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o_0.28_orbitals.02588640-a5ae-48e6-b28b-f6759886ab70.json
@@ -19,20 +19,5 @@
         "num_qubits": 909,
         "t_count": 53283653456
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1363,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 995841.8577229999,
-        "num_qubits": 1244648,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o_0.60_orbitals.a92f6594-5ccc-4385-9cb5-8c21b4407dcf.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_o_0.60_orbitals.a92f6594-5ccc-4385-9cb5-8c21b4407dcf.json
@@ -19,20 +19,5 @@
         "num_qubits": 1975,
         "t_count": 1494335097344
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2962,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 27927604.775332995,
-        "num_qubits": 2891638,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_s_0.32_orbitals.886855d3-f1a7-4004-a736-417360e81d0a.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_s_0.32_orbitals.886855d3-f1a7-4004-a736-417360e81d0a.json
@@ -19,20 +19,5 @@
         "num_qubits": 1019,
         "t_count": 44627003112
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1528,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 834229.3806009999,
-        "num_qubits": 1363778,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_s_0.64_orbitals.57830810-1133-4c19-9a19-30183dd86a9f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.c_s_0.64_orbitals.57830810-1133-4c19-9a19-30183dd86a9f.json
@@ -19,20 +19,5 @@
         "num_qubits": 2097,
         "t_count": 1176798497152
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3145,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 21996192.366232,
-        "num_qubits": 3053044,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cl2_0.36_orbitals.c01649e2-8c5c-4827-a037-1ede2159e558.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cl2_0.36_orbitals.c01649e2-8c5c-4827-a037-1ede2159e558.json
@@ -19,20 +19,5 @@
         "num_qubits": 1167,
         "t_count": 114299242464
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1750,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2136525.14188,
-        "num_qubits": 1524062,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cl2_0.68_orbitals.35e4c771-0f4f-4413-b42f-132f1e606cb0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cl2_0.68_orbitals.35e4c771-0f4f-4413-b42f-132f1e606cb0.json
@@ -19,20 +19,5 @@
         "num_qubits": 2220,
         "t_count": 1251274656280
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3330,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 23386615.621802002,
-        "num_qubits": 3196900,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.202e6184-1e7d-4c02-a82a-f588b6abf809.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.202e6184-1e7d-4c02-a82a-f588b6abf809.json
@@ -19,20 +19,5 @@
         "num_qubits": 574,
         "t_count": 24212408000
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 861,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 452488.906852,
-        "num_qubits": 899914,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.61ad4cfe-b057-4dd8-bd06-ed56347745c1.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.61ad4cfe-b057-4dd8-bd06-ed56347745c1.json
@@ -19,20 +19,5 @@
         "num_qubits": 575,
         "t_count": 47401404192
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 862,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 885834.78904,
-        "num_qubits": 1039438,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.9030e9c9-0323-413c-a98e-aba16b180ba7.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.18_orbitals.9030e9c9-0323-413c-a98e-aba16b180ba7.json
@@ -19,20 +19,5 @@
         "num_qubits": 574,
         "t_count": 23031711424
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 861,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 430423.45768999995,
-        "num_qubits": 1019242,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.7c8f0a36-cda5-4b33-bb46-4e58a15b37a1.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.7c8f0a36-cda5-4b33-bb46-4e58a15b37a1.json
@@ -19,20 +19,5 @@
         "num_qubits": 826,
         "t_count": 104417724344
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1239,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 1951386.479801,
-        "num_qubits": 1371070,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.c7c653b0-4440-4a36-a66b-8b81a9a351c7.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.c7c653b0-4440-4a36-a66b-8b81a9a351c7.json
@@ -19,20 +19,5 @@
         "num_qubits": 827,
         "t_count": 222760536096
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1240,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 4162913.8827559995,
-        "num_qubits": 1591250,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.fc25a232-d249-4e1c-a9ec-360cab33f779.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.cr_dimer.26_orbitals.fc25a232-d249-4e1c-a9ec-360cab33f779.json
@@ -19,20 +19,5 @@
         "num_qubits": 828,
         "t_count": 450453571720
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1242,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 9881906.325159002,
-        "num_qubits": 1686516,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.f2_0.28_orbitals.94fc2317-29af-43a1-aaec-dade9850ca27.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.f2_0.28_orbitals.94fc2317-29af-43a1-aaec-dade9850ca27.json
@@ -19,20 +19,5 @@
         "num_qubits": 908,
         "t_count": 27556185832
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1362,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 425477.906868,
-        "num_qubits": 1181764,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.f2_0.60_orbitals.3fb371ad-c738-40ae-b9ae-80e5bce8f2ac.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.f2_0.60_orbitals.3fb371ad-c738-40ae-b9ae-80e5bce8f2ac.json
@@ -19,20 +19,5 @@
         "num_qubits": 1977,
         "t_count": 1615332379136
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2965,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 30188495.218917005,
-        "num_qubits": 2875852,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.44_orbitals.adecdd92-73c7-416d-90da-b7a3da7ed50b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.44_orbitals.adecdd92-73c7-416d-90da-b7a3da7ed50b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1349,
         "t_count": 73853503360
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2023,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1141215.703309,
-        "num_qubits": 1659728,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.0270434672579356e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.44_orbitals.d3bcc63c-57ad-4346-8290-e36447186440.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.44_orbitals.d3bcc63c-57ad-4346-8290-e36447186440.json
@@ -19,20 +19,5 @@
         "num_qubits": 1349,
         "t_count": 74223126400
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2023,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1146906.412647,
-        "num_qubits": 1659728,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 6.130820171164333e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.45_orbitals.4970c526-817f-4c04-8d7e-797526d5948d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.45_orbitals.4970c526-817f-4c04-8d7e-797526d5948d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1376,
         "t_count": 77736642432
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2064,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1201274.876597,
-        "num_qubits": 1688608,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.927587728092012e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.53_orbitals.d27fb590-4e90-4d5a-bdb8-37fbf22f528b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.53_orbitals.d27fb590-4e90-4d5a-bdb8-37fbf22f528b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1648,
         "t_count": 238949632128
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2472,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4467669.430633,
-        "num_qubits": 2044624,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.131840282462224e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.54_orbitals.03c70feb-49b8-4113-831a-05e3ae55c66b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.54_orbitals.03c70feb-49b8-4113-831a-05e3ae55c66b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1679,
         "t_count": 255916116096
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2518,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4784958.709845,
-        "num_qubits": 2078558,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.2259930738019823e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.54_orbitals.41907f9f-923d-49e3-80a9-519962110ae7.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.54_orbitals.41907f9f-923d-49e3-80a9-519962110ae7.json
@@ -19,20 +19,5 @@
         "num_qubits": 1681,
         "t_count": 255679137920
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2521,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4780621.596123,
-        "num_qubits": 2080724,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.4120339388541068e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.55_orbitals.0e936335-6370-4587-92f0-02eafaf650ed.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.55_orbitals.0e936335-6370-4587-92f0-02eafaf650ed.json
@@ -19,20 +19,5 @@
         "num_qubits": 1707,
         "t_count": 265221703808
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2560,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4959052.1962210005,
-        "num_qubits": 2108882,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.4186950328634848e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.55_orbitals.ad9ceeaf-d7be-46b7-95a9-15bfd33f5022.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.55_orbitals.ad9ceeaf-d7be-46b7-95a9-15bfd33f5022.json
@@ -19,20 +19,5 @@
         "num_qubits": 1707,
         "t_count": 266003941504
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2560,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4973692.603921001,
-        "num_qubits": 2108882,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.4733643313105063e-07
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.58_orbitals.a7cd2501-2f67-4fcd-b428-f6620f3596fe.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.fe_red.58_orbitals.a7cd2501-2f67-4fcd-b428-f6620f3596fe.json
@@ -19,20 +19,5 @@
         "num_qubits": 1791,
         "t_count": 308661586048
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2686,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 5771612.960158,
-        "num_qubits": 2199854,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.1507033322402685e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_c_o_0.38_orbitals.d58cb72b-e144-4164-aec0-309aaef6394c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_c_o_0.38_orbitals.d58cb72b-e144-4164-aec0-309aaef6394c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1225,
         "t_count": 121723684976
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1837,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2274974.7396789994,
-        "num_qubits": 1586876,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o2_0.38_orbitals.85743547-31ba-48ff-b854-220e4b9b620f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o2_0.38_orbitals.85743547-31ba-48ff-b854-220e4b9b620f.json
@@ -19,20 +19,5 @@
         "num_qubits": 1228,
         "t_count": 162651703408
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1842,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3040029.447631,
-        "num_qubits": 1589764,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o_0.24_orbitals.80d75334-b878-41ec-99a8-b21277f3df60.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o_0.24_orbitals.80d75334-b878-41ec-99a8-b21277f3df60.json
@@ -19,20 +19,5 @@
         "num_qubits": 773,
         "t_count": 11467294336
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1159,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 177072.58947099998,
-        "num_qubits": 852496,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o_0.58_orbitals.4e395cc5-b5d2-4b82-95a2-1276262386c8.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_o_0.58_orbitals.4e395cc5-b5d2-4b82-95a2-1276262386c8.json
@@ -19,20 +19,5 @@
         "num_qubits": 1914,
         "t_count": 771330935168
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2871,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 14415816.233996002,
-        "num_qubits": 2332702,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_s_0.28_orbitals.f2f09d9f-8328-4d4a-ba91-089f9e56bf0d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_s_0.28_orbitals.f2f09d9f-8328-4d4a-ba91-089f9e56bf0d.json
@@ -19,20 +19,5 @@
         "num_qubits": 877,
         "t_count": 14710015616
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1315,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 227172.185536,
-        "num_qubits": 1132168,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_s_0.62_orbitals.ec0baf59-05f5-49df-b5e5-8f887d822a10.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h2_s_0.62_orbitals.ec0baf59-05f5-49df-b5e5-8f887d822a10.json
@@ -19,20 +19,5 @@
         "num_qubits": 2034,
         "t_count": 851752520064
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3051,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 15919291.662694998,
-        "num_qubits": 2462662,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h3_c_o_h_0.48_orbitals.fc3586af-0290-4a4a-81e1-422a1d331a09.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h3_c_o_h_0.48_orbitals.fc3586af-0290-4a4a-81e1-422a1d331a09.json
@@ -19,20 +19,5 @@
         "num_qubits": 1510,
         "t_count": 247534979184
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2265,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4626732.113286,
-        "num_qubits": 1895170,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h3_c_s_h_0.52_orbitals.ff159145-fd97-486b-bf16-fc766b362ea3.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h3_c_s_h_0.52_orbitals.ff159145-fd97-486b-bf16-fc766b362ea3.json
@@ -19,20 +19,5 @@
         "num_qubits": 1675,
         "t_count": 315814054000
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2512,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 5903125.455158,
-        "num_qubits": 2074226,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_c_n_0.33_orbitals.94db0c2c-89f6-4c3d-b886-a3a6a2bdad1d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_c_n_0.33_orbitals.94db0c2c-89f6-4c3d-b886-a3a6a2bdad1d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1050,
         "t_count": 79714060256
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1575,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1489843.1937529999,
-        "num_qubits": 1396990,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_cl_0.23_orbitals.fa3bc2a8-8067-4088-909a-2ddfa655ebfb.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_cl_0.23_orbitals.fa3bc2a8-8067-4088-909a-2ddfa655ebfb.json
@@ -19,20 +19,5 @@
         "num_qubits": 742,
         "t_count": 9130673664
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1113,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 140996.621484,
-        "num_qubits": 825330,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_cl_0.48_orbitals.f0637f33-3c53-4f01-8cf7-cfd9c6f39a51.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_cl_0.48_orbitals.f0637f33-3c53-4f01-8cf7-cfd9c6f39a51.json
@@ -19,20 +19,5 @@
         "num_qubits": 1558,
         "t_count": 202590914672
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2337,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3786773.599711,
-        "num_qubits": 1947154,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_f_0.19_orbitals.b59bd259-4941-4cec-bca5-e2795c35d8e0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_f_0.19_orbitals.b59bd259-4941-4cec-bca5-e2795c35d8e0.json
@@ -19,20 +19,5 @@
         "num_qubits": 618,
         "t_count": 2984347040
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 927,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 46093.721898,
-        "num_qubits": 717822,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_f_0.44_orbitals.daa86ad6-bda9-4d47-a50d-4ec34801bd82.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_f_0.44_orbitals.daa86ad6-bda9-4d47-a50d-4ec34801bd82.json
@@ -19,20 +19,5 @@
         "num_qubits": 1446,
         "t_count": 162699937904
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2169,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3041074.9842449995,
-        "num_qubits": 1825858,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_o_cl_0.37_orbitals.bd44e482-057d-42c3-a052-cbd952fa8025.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.h_o_cl_0.37_orbitals.bd44e482-057d-42c3-a052-cbd952fa8025.json
@@ -19,20 +19,5 @@
         "num_qubits": 1197,
         "t_count": 126875338864
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1795,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2371304.865385,
-        "num_qubits": 1556552,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li2_0.28_orbitals.e7d3b8bd-ff6c-44f6-8a9e-b9b75396cee0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li2_0.28_orbitals.e7d3b8bd-ff6c-44f6-8a9e-b9b75396cee0.json
@@ -19,20 +19,5 @@
         "num_qubits": 842,
         "t_count": 7108986392
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1263,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 109825.96466000001,
-        "num_qubits": 912030,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li2_0.60_orbitals.410cd417-988a-4f7f-99ad-93dda7eacdcb.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li2_0.60_orbitals.410cd417-988a-4f7f-99ad-93dda7eacdcb.json
@@ -19,20 +19,5 @@
         "num_qubits": 1906,
         "t_count": 161046464504
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2859,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3011188.780196,
-        "num_qubits": 2324038,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_f_0.28_orbitals.80043b93-039c-4d5a-abcb-84b8f25f7abb.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_f_0.28_orbitals.80043b93-039c-4d5a-abcb-84b8f25f7abb.json
@@ -19,20 +19,5 @@
         "num_qubits": 874,
         "t_count": 7030474264
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1311,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 108621.40057099999,
-        "num_qubits": 939774,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_f_0.60_orbitals.b80345ff-5df9-4fb3-86ab-0a25188b296d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_f_0.60_orbitals.b80345ff-5df9-4fb3-86ab-0a25188b296d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1973,
         "t_count": 376263936256
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2959,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 7033638.987582999,
-        "num_qubits": 2396960,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_h_0.19_orbitals.92917287-d937-410c-bb70-c1f34224fab7.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_h_0.19_orbitals.92917287-d937-410c-bb70-c1f34224fab7.json
@@ -19,20 +19,5 @@
         "num_qubits": 594,
         "t_count": 1465763136
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 891,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 22651.353389,
-        "num_qubits": 582966,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_h_0.44_orbitals.d15db194-aa2d-4de9-8f86-fcffeb82f38b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.li_h_0.44_orbitals.d15db194-aa2d-4de9-8f86-fcffeb82f38b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1393,
         "t_count": 84899399672
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2089,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1311228.7672920001,
-        "num_qubits": 1707380,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.1ade03f3-06b1-4e95-b271-fea5a6343829.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.1ade03f3-06b1-4e95-b271-fea5a6343829.json
@@ -19,20 +19,5 @@
         "num_qubits": 468,
         "t_count": 4324132096
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 702,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 66765.853678,
-        "num_qubits": 688860,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.4738046590452183e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.590c2f0b-964b-4d09-96ad-101a9be59cab.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.590c2f0b-964b-4d09-96ad-101a9be59cab.json
@@ -19,20 +19,5 @@
         "num_qubits": 469,
         "t_count": 8640922960
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 703,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 161489.173019,
-        "num_qubits": 768128,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.803187286415855e-14
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.a9c90f98-6557-44d2-9ca0-0c9122f4080c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.a9c90f98-6557-44d2-9ca0-0c9122f4080c.json
@@ -19,20 +19,5 @@
         "num_qubits": 468,
         "t_count": 4346676480
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 702,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 67114.01004,
-        "num_qubits": 705244,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.0989177644065197e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.de3ea361-c2d3-4ab6-add4-ccd43cea6aa8.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.14_orbitals.de3ea361-c2d3-4ab6-add4-ccd43cea6aa8.json
@@ -19,20 +19,5 @@
         "num_qubits": 467,
         "t_count": 2119074992
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 700,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 32724.953456,
-        "num_qubits": 587194,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 9.441490623124992e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.30_orbitals.6c39d3a7-c71a-4049-a8c7-3a3a4b61d8da.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.30_orbitals.6c39d3a7-c71a-4049-a8c7-3a3a4b61d8da.json
@@ -19,20 +19,5 @@
         "num_qubits": 929,
         "t_count": 56690345704
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1393,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1059632.262763,
-        "num_qubits": 1266308,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.8968317191680384e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.6e617348-d0b3-4b6d-9923-ea54ba5cf751.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.6e617348-d0b3-4b6d-9923-ea54ba5cf751.json
@@ -19,20 +19,5 @@
         "num_qubits": 955,
         "t_count": 62324868840
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1432,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1164965.3729779997,
-        "num_qubits": 1294466,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.259141151650955e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.a16168e2-98cd-430d-a180-84f64b4d5e75.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.a16168e2-98cd-430d-a180-84f64b4d5e75.json
@@ -19,20 +19,5 @@
         "num_qubits": 956,
         "t_count": 124247082832
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1434,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 2322131.2408799995,
-        "num_qubits": 1313620,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.5233173694564974e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.ff0da1e2-2c76-4589-aefa-c13bb1a1ef8f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mn_mono.31_orbitals.ff0da1e2-2c76-4589-aefa-c13bb1a1ef8f.json
@@ -19,20 +19,5 @@
         "num_qubits": 955,
         "t_count": 62350034664
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1432,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1165429.037591,
-        "num_qubits": 1294466,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.836018388955582e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.69_orbitals.79b74ad4-afa8-458f-87a3-a5ec339056c6.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.69_orbitals.79b74ad4-afa8-458f-87a3-a5ec339056c6.json
@@ -19,20 +19,5 @@
         "num_qubits": 2176,
         "t_count": 518492653832
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3264,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 9696483.131195,
-        "num_qubits": 2616448,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.7672992900240902e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.69_orbitals.e3a07092-d1e5-4867-a4d7-d0258f9df6db.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.69_orbitals.e3a07092-d1e5-4867-a4d7-d0258f9df6db.json
@@ -19,20 +19,5 @@
         "num_qubits": 2176,
         "t_count": 510313761032
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3264,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 9543657.899234,
-        "num_qubits": 2616448,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.2583715817657497e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.70_orbitals.138733f0-08f5-4077-b848-813c8ec53c79.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo2_n2.70_orbitals.138733f0-08f5-4077-b848-813c8ec53c79.json
@@ -19,20 +19,5 @@
         "num_qubits": 2205,
         "t_count": 515478522120
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3307,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 9640873.515853997,
-        "num_qubits": 2648216,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.1983271953334021e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.30_orbitals.35c1aee4-4ef3-4e18-bc2a-377cf45e8fa1.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.30_orbitals.35c1aee4-4ef3-4e18-bc2a-377cf45e8fa1.json
@@ -19,20 +19,5 @@
         "num_qubits": 896,
         "t_count": 28274132608
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1344,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 436706.741792,
-        "num_qubits": 1168768,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.3308741300235366e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.31_orbitals.00ba4917-d66a-4335-819f-43390dfc9929.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.31_orbitals.00ba4917-d66a-4335-819f-43390dfc9929.json
@@ -19,20 +19,5 @@
         "num_qubits": 953,
         "t_count": 15581218328
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1429,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 240776.040389,
-        "num_qubits": 1008556,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 7.590745560471297e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.46_orbitals.b9cc699a-80f8-4280-9731-23dee4d5a6a5.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.46_orbitals.b9cc699a-80f8-4280-9731-23dee4d5a6a5.json
@@ -19,20 +19,5 @@
         "num_qubits": 1452,
         "t_count": 175247853560
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2178,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3276255.1770940004,
-        "num_qubits": 1832356,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.5399753267406963e-07
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.46_orbitals.dfd78a05-437d-4667-88d7-7e2a3384b816.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2.46_orbitals.dfd78a05-437d-4667-88d7-7e2a3384b816.json
@@ -19,20 +19,5 @@
         "num_qubits": 1452,
         "t_count": 161024968696
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2178,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3010433.2194959996,
-        "num_qubits": 1832356,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.2059414343429678e-07
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.25_orbitals.09b81c3d-aee1-4bc3-98ce-a72da477b108.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.25_orbitals.09b81c3d-aee1-4bc3-98ce-a72da477b108.json
@@ -19,20 +19,5 @@
         "num_qubits": 768,
         "t_count": 17324115584
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1152,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 323851.13773300004,
-        "num_qubits": 1091584,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.7659863001935583e-13
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.3fa3940d-8a68-44ae-9223-7346404651e6.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.3fa3940d-8a68-44ae-9223-7346404651e6.json
@@ -19,20 +19,5 @@
         "num_qubits": 953,
         "t_count": 15579383320
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1429,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 240759.79593300002,
-        "num_qubits": 1008556,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.2214475944995235e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.4c240146-6b8b-4fa5-88e4-41cbd39c8ac3.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.4c240146-6b8b-4fa5-88e4-41cbd39c8ac3.json
@@ -19,20 +19,5 @@
         "num_qubits": 953,
         "t_count": 15580169752
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1429,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 240772.732348,
-        "num_qubits": 1008556,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.976053894730376e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b628f4be-582f-4f23-96eb-c8b9e0005e4a.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b628f4be-582f-4f23-96eb-c8b9e0005e4a.json
@@ -19,20 +19,5 @@
         "num_qubits": 951,
         "t_count": 15354594840
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1426,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 237266.878098,
-        "num_qubits": 1006822,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 6.809816943369116e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b900c4a3-fe87-4df7-96b7-2767ccdc1d56.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b900c4a3-fe87-4df7-96b7-2767ccdc1d56.json
@@ -19,20 +19,5 @@
         "num_qubits": 953,
         "t_count": 15575189016
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1429,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 240695.08100699997,
-        "num_qubits": 1008556,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.426595716634608e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.39_orbitals.87d59f7c-e397-42dc-aa6e-00200d8697aa.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.39_orbitals.87d59f7c-e397-42dc-aa6e-00200d8697aa.json
@@ -19,20 +19,5 @@
         "num_qubits": 1172,
         "t_count": 236289001584
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1758,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 4416350.712039,
-        "num_qubits": 1547548,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.62023203266714e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.7fc4c1d7-3469-40a3-9cd8-4354b6acf01d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.7fc4c1d7-3469-40a3-9cd8-4354b6acf01d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1374,
         "t_count": 88178100096
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2061,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1362530.332787,
-        "num_qubits": 1686442,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.7839320879077976e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c436c481-00d1-49ec-8d0e-0a5e83a8df19.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c436c481-00d1-49ec-8d0e-0a5e83a8df19.json
@@ -19,20 +19,5 @@
         "num_qubits": 1374,
         "t_count": 83618891648
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2061,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1292069.347091,
-        "num_qubits": 1686442,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.0320377914033745e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c582e543-075c-4fa1-b189-5e7455286d82.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c582e543-075c-4fa1-b189-5e7455286d82.json
@@ -19,20 +19,5 @@
         "num_qubits": 1374,
         "t_count": 86539175808
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2061,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1337077.476228,
-        "num_qubits": 1686442,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.0517495296458094e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.eadd62e9-ee3d-4193-94de-7735a529edce.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.45_orbitals.eadd62e9-ee3d-4193-94de-7735a529edce.json
@@ -19,20 +19,5 @@
         "num_qubits": 1374,
         "t_count": 88023959424
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2061,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1360124.5500820002,
-        "num_qubits": 1686442,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.2641610776220107e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.349e9cbe-d675-411f-b6b8-be846c27902c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.349e9cbe-d675-411f-b6b8-be846c27902c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1709,
         "t_count": 1010077010304
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2563,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 18878495.969506003,
-        "num_qubits": 2539720,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.63888127383308e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.aaae8d93-cb88-41ee-8f11-c70cc9b0d7fb.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.aaae8d93-cb88-41ee-8f11-c70cc9b0d7fb.json
@@ -19,20 +19,5 @@
         "num_qubits": 1709,
         "t_count": 1154667252096
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2563,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 21580615.582093,
-        "num_qubits": 2539720,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.190646154738395e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.db75bf65-181b-40c2-b978-26453437c2b0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.55_orbitals.db75bf65-181b-40c2-b978-26453437c2b0.json
@@ -19,20 +19,5 @@
         "num_qubits": 1708,
         "t_count": 594872109312
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2562,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 11119481.047996,
-        "num_qubits": 2519524,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.1236666458574717e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.69_orbitals.3eccbccf-e84a-44b9-b775-cef772cd84f0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.69_orbitals.3eccbccf-e84a-44b9-b775-cef772cd84f0.json
@@ -19,20 +19,5 @@
         "num_qubits": 2174,
         "t_count": 3826493950624
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3261,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 71514244.92851901,
-        "num_qubits": 3728410,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.986698983467292e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.69_orbitals.ab482d50-9a85-48d9-aa17-83dcbb38614b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.69_orbitals.ab482d50-9a85-48d9-aa17-83dcbb38614b.json
@@ -19,20 +19,5 @@
         "num_qubits": 2180,
         "t_count": 2132561889968
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3270,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 39859502.648898005,
-        "num_qubits": 3162412,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.8106493065168666e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.70_orbitals.5547bb48-fac6-4426-91ad-c4853ce421aa.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.mo_n2_pincer.70_orbitals.5547bb48-fac6-4426-91ad-c4853ce421aa.json
@@ -19,20 +19,5 @@
         "num_qubits": 2208,
         "t_count": 4284570667680
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3312,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 80075692.49281399,
-        "num_qubits": 3782368,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.640652007069778e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_0.28_orbitals.b9c35349-927d-47d5-8e0c-e054bbf4e4e0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_0.28_orbitals.b9c35349-927d-47d5-8e0c-e054bbf4e4e0.json
@@ -19,20 +19,5 @@
         "num_qubits": 908,
         "t_count": 29639706344
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1362,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 553979.86184,
-        "num_qubits": 1243204,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_0.60_orbitals.666185aa-b65d-4f73-8846-ae9693388d9d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_0.60_orbitals.666185aa-b65d-4f73-8846-ae9693388d9d.json
@@ -19,20 +19,5 @@
         "num_qubits": 1977,
         "t_count": 1505760381440
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2965,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 28140765.266451,
-        "num_qubits": 2894284,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_h4_0.48_orbitals.828c931b-4d5a-486e-ba26-abb293c1ccef.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n2_h4_0.48_orbitals.828c931b-4d5a-486e-ba26-abb293c1ccef.json
@@ -19,20 +19,5 @@
         "num_qubits": 1562,
         "t_count": 614230132968
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2343,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 11479839.893135002,
-        "num_qubits": 1969918,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n_h3_0.29_orbitals.77c3a92c-066c-4043-a4a1-5e8324014d0b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.n_h3_0.29_orbitals.77c3a92c-066c-4043-a4a1-5e8324014d0b.json
@@ -19,20 +19,5 @@
         "num_qubits": 936,
         "t_count": 44159862504
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1404,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 681885.2211359999,
-        "num_qubits": 1212088,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na2_0.36_orbitals.4fb7e994-8e7a-4acd-86d4-bb52db824cfc.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na2_0.36_orbitals.4fb7e994-8e7a-4acd-86d4-bb52db824cfc.json
@@ -19,20 +19,5 @@
         "num_qubits": 1125,
         "t_count": 26684491520
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1687,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 412147.02655400004,
-        "num_qubits": 1174064,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na2_0.68_orbitals.620e9ff4-07bf-4767-9237-d39aa659b8e5.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na2_0.68_orbitals.620e9ff4-07bf-4767-9237-d39aa659b8e5.json
@@ -19,20 +19,5 @@
         "num_qubits": 2144,
         "t_count": 479596906896
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3216,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 8965471.790427001,
-        "num_qubits": 2581792,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na_cl_0.36_orbitals.da831b60-89ce-4c01-96f9-c9f8a4512aab.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na_cl_0.36_orbitals.da831b60-89ce-4c01-96f9-c9f8a4512aab.json
@@ -19,20 +19,5 @@
         "num_qubits": 1127,
         "t_count": 28096136960
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1690,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 434000.422208,
-        "num_qubits": 1159414,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na_cl_0.68_orbitals.01ec60f7-d38a-4c33-a498-659a388e10ee.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.na_cl_0.68_orbitals.01ec60f7-d38a-4c33-a498-659a388e10ee.json
@@ -19,20 +19,5 @@
         "num_qubits": 2217,
         "t_count": 590059145616
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3325,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 11030717.787609,
-        "num_qubits": 2661212,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.15_orbitals.b4968ccd-6711-4173-8f80-f16094b3e0cd.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.15_orbitals.b4968ccd-6711-4173-8f80-f16094b3e0cd.json
@@ -19,20 +19,5 @@
         "num_qubits": 490,
         "t_count": 1001931872
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 735,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 15475.722958999999,
-        "num_qubits": 512766,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.15_orbitals.e0de65ed-e45e-46e0-a57b-c6ad4efbdafe.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.15_orbitals.e0de65ed-e45e-46e0-a57b-c6ad4efbdafe.json
@@ -19,20 +19,5 @@
         "num_qubits": 490,
         "t_count": 1012941920
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 735,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 15646.090681,
-        "num_qubits": 512766,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.42_orbitals.881f5275-83eb-470c-80fe-eebb7ced30e9.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.42_orbitals.881f5275-83eb-470c-80fe-eebb7ced30e9.json
@@ -19,20 +19,5 @@
         "num_qubits": 1341,
         "t_count": 100754393080
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2011,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1555880.2849209998,
-        "num_qubits": 1651064,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.42_orbitals.a2ad41b8-37bb-44e1-be3e-df1052952e9c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ozone.42_orbitals.a2ad41b8-37bb-44e1-be3e-df1052952e9c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1342,
         "t_count": 189685041264
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2013,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 3545202.805513,
-        "num_qubits": 1713226,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p2_0.36_orbitals.084acde0-d1c7-4721-aa45-acb4832e0998.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p2_0.36_orbitals.084acde0-d1c7-4721-aa45-acb4832e0998.json
@@ -19,20 +19,5 @@
         "num_qubits": 1168,
         "t_count": 227239528528
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1752,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 4246817.7404310005,
-        "num_qubits": 1805104,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p2_0.68_orbitals.23a06c81-be81-4f88-98ab-9e7030c909ef.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p2_0.68_orbitals.23a06c81-be81-4f88-98ab-9e7030c909ef.json
@@ -19,20 +19,5 @@
         "num_qubits": 2221,
         "t_count": 2720518900384
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3331,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 50843516.331184,
-        "num_qubits": 3217096,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p_h3_0.33_orbitals.af399f2b-a4f8-4fec-aca2-7c126ed989a5.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.p_h3_0.33_orbitals.af399f2b-a4f8-4fec-aca2-7c126ed989a5.json
@@ -19,20 +19,5 @@
         "num_qubits": 1047,
         "t_count": 58982008688
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1570,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1102502.8496939999,
-        "num_qubits": 1394102,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0001.14_orbitals.be3812d3-5975-4736-8a23-96d64e50e66a.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0001.14_orbitals.be3812d3-5975-4736-8a23-96d64e50e66a.json
@@ -19,20 +19,5 @@
         "num_qubits": 517,
         "t_count": 8071677200
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 775,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 124615.86568699998,
-        "num_qubits": 630544,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0002.69_orbitals.0deae366-42de-4081-914d-db85c6b47168.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0002.69_orbitals.0deae366-42de-4081-914d-db85c6b47168.json
@@ -19,20 +19,5 @@
         "num_qubits": 2324,
         "t_count": 10654463298432
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3486,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 233737829.40462503,
-        "num_qubits": 4060668,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0003.31_orbitals.472bbfb1-c081-4df6-b966-32ce1194ab8c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0003.31_orbitals.472bbfb1-c081-4df6-b966-32ce1194ab8c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1052,
         "t_count": 20010239536
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1578,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 309094.449787,
-        "num_qubits": 1094100,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0004.70_orbitals.c9809448-2f3d-40d4-858d-6288a4703af4.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0004.70_orbitals.c9809448-2f3d-40d4-858d-6288a4703af4.json
@@ -19,20 +19,5 @@
         "num_qubits": 2421,
         "t_count": 717735070080
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3631,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 13418629.055952998,
-        "num_qubits": 2882144,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0005.14_orbitals.a41a284c-7baa-438e-9323-532091c7a78f.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0005.14_orbitals.a41a284c-7baa-438e-9323-532091c7a78f.json
@@ -19,20 +19,5 @@
         "num_qubits": 518,
         "t_count": 4181591240
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 777,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 64562.558798,
-        "num_qubits": 631122,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0006.14_orbitals.d28f02ba-d43f-4df9-a01a-f1e8ac326e08.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0006.14_orbitals.d28f02ba-d43f-4df9-a01a-f1e8ac326e08.json
@@ -19,20 +19,5 @@
         "num_qubits": 516,
         "t_count": 3959293128
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 774,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 61131.635164,
-        "num_qubits": 629388,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0007.31_orbitals.d3c058ec-9b13-4a9a-aba0-d3f19091c47b.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0007.31_orbitals.d3c058ec-9b13-4a9a-aba0-d3f19091c47b.json
@@ -19,20 +19,5 @@
         "num_qubits": 1049,
         "t_count": 18988926512
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1573,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 293327.949139,
-        "num_qubits": 1091788,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0008.14_orbitals.af56de36-35aa-44b9-8eb7-b9c1e8f7d0f3.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0008.14_orbitals.af56de36-35aa-44b9-8eb7-b9c1e8f7d0f3.json
@@ -19,20 +19,5 @@
         "num_qubits": 516,
         "t_count": 4042130632
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 774,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 62409.942293000015,
-        "num_qubits": 629388,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0009.69_orbitals.8f373cb0-952d-48c6-a871-8a10e52e7c19.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0009.69_orbitals.8f373cb0-952d-48c6-a871-8a10e52e7c19.json
@@ -19,20 +19,5 @@
         "num_qubits": 2320,
         "t_count": 720211806592
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3480,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 13464630.401525002,
-        "num_qubits": 2772400,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0010.30_orbitals.7cc1ed5c-0dcb-4315-9e51-2ae94b5cdd02.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0010.30_orbitals.7cc1ed5c-0dcb-4315-9e51-2ae94b5cdd02.json
@@ -19,20 +19,5 @@
         "num_qubits": 1025,
         "t_count": 19212273200
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1537,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 296755.57209599996,
-        "num_qubits": 1070980,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0011.31_orbitals.0021e256-8e13-42db-839d-e9155e8af82c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.planted_solution_0011.31_orbitals.0021e256-8e13-42db-839d-e9155e8af82c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1051,
         "t_count": 18905040432
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1576,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 292036.66555700003,
-        "num_qubits": 1093522,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.12_orbitals.dcf2b441-b297-4a89-ae18-5778ec2d674d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.12_orbitals.dcf2b441-b297-4a89-ae18-5778ec2d674d.json
@@ -19,20 +19,5 @@
         "num_qubits": 383,
         "t_count": 199971776
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 574,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 3094.293415,
-        "num_qubits": 426430,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.7374285459164e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.14_orbitals.28bd4997-c04c-4914-9984-0101713041fe.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.14_orbitals.28bd4997-c04c-4914-9984-0101713041fe.json
@@ -19,20 +19,5 @@
         "num_qubits": 432,
         "t_count": 268506048
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 648,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 4156.619229,
-        "num_qubits": 459280,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.7636563627795825e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.21_orbitals.89253c8f-0f01-4046-a138-1bada22f0a6a.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.21_orbitals.89253c8f-0f01-4046-a138-1bada22f0a6a.json
@@ -19,20 +19,5 @@
         "num_qubits": 643,
         "t_count": 2787362112
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 964,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 43084.945855,
-        "num_qubits": 739786,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.003743402632097e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.23_orbitals.68db6781-dd54-43c4-b667-7b754c4d5cdb.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.23_orbitals.68db6781-dd54-43c4-b667-7b754c4d5cdb.json
@@ -19,20 +19,5 @@
         "num_qubits": 693,
         "t_count": 3484042672
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1039,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 53864.630612999994,
-        "num_qubits": 783136,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 6.081756260800853e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.33_orbitals.6346b7fe-a4a5-4b10-a79b-706d4339923e.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.33_orbitals.6346b7fe-a4a5-4b10-a79b-706d4339923e.json
@@ -19,20 +19,5 @@
         "num_qubits": 1013,
         "t_count": 18508777224
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1519,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 286066.1275739999,
-        "num_qubits": 1060576,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.678060379090119e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.42_orbitals.842d2152-2f91-4dce-b088-7ed26afb2381.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.42_orbitals.842d2152-2f91-4dce-b088-7ed26afb2381.json
@@ -19,20 +19,5 @@
         "num_qubits": 1293,
         "t_count": 72133052288
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1939,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1114484.0297500002,
-        "num_qubits": 1599080,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.2953157493176507e-08
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.45_orbitals.d3ecd428-ee03-4d8b-aa14-af4d935781ed.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.45_orbitals.d3ecd428-ee03-4d8b-aa14-af4d935781ed.json
@@ -19,20 +19,5 @@
         "num_qubits": 1376,
         "t_count": 86421997440
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2064,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1335367.806427,
-        "num_qubits": 1688608,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.825746327947868e-09
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.6_orbitals.4357d5bb-ed2b-466a-947b-e868afb81d3d.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.6_orbitals.4357d5bb-ed2b-466a-947b-e868afb81d3d.json
@@ -19,20 +19,5 @@
         "num_qubits": 211,
         "t_count": 16784944
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 316,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 13,
-        "runtime": 206.154708,
-        "num_qubits": 225674,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 7.541163080436849e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.9_orbitals.b164af91-a758-445c-8e78-610ffd2ad795.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_macho.9_orbitals.b164af91-a758-445c-8e78-610ffd2ad795.json
@@ -19,20 +19,5 @@
         "num_qubits": 305,
         "t_count": 127562592
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 457,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 1972.7066059999997,
-        "num_qubits": 373780,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 9.752305231719762e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.10_orbitals.d937e005-3688-4138-9465-426798087395.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.10_orbitals.d937e005-3688-4138-9465-426798087395.json
@@ -19,20 +19,5 @@
         "num_qubits": 325,
         "t_count": 269837224
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 487,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 4170.1820769999995,
-        "num_qubits": 401616,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 3.3371086155259294e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.34_orbitals.a475af8e-cb0b-4533-906d-a6b8eda313e7.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.34_orbitals.a475af8e-cb0b-4533-906d-a6b8eda313e7.json
@@ -19,20 +19,5 @@
         "num_qubits": 1039,
         "t_count": 18332747528
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1558,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 17,
-        "runtime": 283378.91831,
-        "num_qubits": 1083118,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 4.220849796163007e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.34_orbitals.bc3520b5-bf25-4a43-892c-8d7e9a690fe2.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.34_orbitals.bc3520b5-bf25-4a43-892c-8d7e9a690fe2.json
@@ -19,20 +19,5 @@
         "num_qubits": 1040,
         "t_count": 39582107520
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1560,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 611415.8310540001,
-        "num_qubits": 1324720,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 2.204864530585426e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.36_orbitals.ace55695-1ca9-4153-8fd4-55ed6658cf8c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.36_orbitals.ace55695-1ca9-4153-8fd4-55ed6658cf8c.json
@@ -19,20 +19,5 @@
         "num_qubits": 1092,
         "t_count": 43199694720
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1638,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 23,
-        "runtime": 737543.523842,
-        "num_qubits": 1970316,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 5.479567000407373e-10
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.9_orbitals.5509795a-90ce-45d6-b03d-db956a5da5b2.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.9_orbitals.5509795a-90ce-45d6-b03d-db956a5da5b2.json
@@ -19,20 +19,5 @@
         "num_qubits": 300,
         "t_count": 61791000
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 450,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 15,
-        "runtime": 957.3147630000001,
-        "num_qubits": 370180,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 6.154920080054809e-12
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.9_orbitals.dab492c3-27fe-4ac3-8c98-de2563caf66c.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.ru_mono.9_orbitals.dab492c3-27fe-4ac3-8c98-de2563caf66c.json
@@ -19,20 +19,5 @@
         "num_qubits": 291,
         "t_count": 58237720
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 436,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 13,
-        "runtime": 902.5953410000001,
-        "num_qubits": 315386,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 1.3169256969537955e-11
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.s_o2_0.46_orbitals.c7cd47fa-1bbd-4859-a0c8-3fd5c287c6db.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.s_o2_0.46_orbitals.c7cd47fa-1bbd-4859-a0c8-3fd5c287c6db.json
@@ -19,20 +19,5 @@
         "num_qubits": 1455,
         "t_count": 444675393768
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 2182,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 8310544.262921,
-        "num_qubits": 2185246,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si2_h6_0.66_orbitals.109f95c5-8561-458c-8f41-72be596b87e6.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si2_h6_0.66_orbitals.109f95c5-8561-458c-8f41-72be596b87e6.json
@@ -19,20 +19,5 @@
         "num_qubits": 2090,
         "t_count": 1400564615704
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3135,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 26176938.864974998,
-        "num_qubits": 3043342,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h2_singlet_0.28_orbitals.240f7830-f4e1-4301-b0af-ab8936851796.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h2_singlet_0.28_orbitals.240f7830-f4e1-4301-b0af-ab8936851796.json
@@ -19,20 +19,5 @@
         "num_qubits": 875,
         "t_count": 14770833024
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1312,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 228109.428136,
-        "num_qubits": 1130002,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h2_singlet_0.62_orbitals.5e1dcd34-1373-4f34-b9df-d738a8cf4db6.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h2_singlet_0.62_orbitals.5e1dcd34-1373-4f34-b9df-d738a8cf4db6.json
@@ -19,20 +19,5 @@
         "num_qubits": 2033,
         "t_count": 427717560576
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3049,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 7995211.792247001,
-        "num_qubits": 2461940,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h4_0.38_orbitals.2eaee11d-c1a0-4d2b-b29b-a38e658572f2.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_h4_0.38_orbitals.2eaee11d-c1a0-4d2b-b29b-a38e658572f2.json
@@ -19,20 +19,5 @@
         "num_qubits": 1187,
         "t_count": 83544639480
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1780,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1561743.680315,
-        "num_qubits": 1545722,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_o_0.32_orbitals.88a6b9fd-e159-4059-9ee5-ba718fd624dc.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_o_0.32_orbitals.88a6b9fd-e159-4059-9ee5-ba718fd624dc.json
@@ -19,20 +19,5 @@
         "num_qubits": 1020,
         "t_count": 82620712784
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 1530,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 19,
-        "runtime": 1544123.6639100001,
-        "num_qubits": 1364500,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_o_0.64_orbitals.8aa559b0-3aae-4850-a2d7-14e037ce26c0.json
+++ b/scripts/resource_estimate_files_20250109/resource_estimate.gsee.si_o_0.64_orbitals.8aa559b0-3aae-4850-a2d7-14e037ce26c0.json
@@ -19,20 +19,5 @@
         "num_qubits": 2095,
         "t_count": 1944182589952
     },
-    "logical-compiled": {
-        "logical_architecture_description": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
-        "num_qubits": 3142,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
-    "physical": {
-        "physical_architecture_description": "Optimistic superconducting hardware model based on that described in https://arxiv.org/abs/2011.03494.",
-        "code_name": "surface",
-        "code_distance": 21,
-        "runtime": 36334844.279721,
-        "num_qubits": 3050398,
-        "t_count": "XXXXXXXXXXXXX",
-        "num_t_factories": 4
-    },
     "value_per_t_gate": 0.0
 }

--- a/src/qb_gsee_benchmark/utils.py
+++ b/src/qb_gsee_benchmark/utils.py
@@ -873,23 +873,27 @@ class BenchmarkData:
                 # re["logical-abstract"]["gate_count"] # SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["logical-abstract"]["circuit_depth"] # SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["logical-abstract"]["t_depth"] # SCHEMA-OPTIONAL.  Not reported at this time.
-                re["logical-compiled"] = {} # object is optional.
-                re["logical-compiled"]["logical_architecture_description"] = d["re_logical_architecture_description"]
-                re["logical-compiled"]["num_qubits"] = d["re_logical_compiled_num_qubits"]
-                re["logical-compiled"]["t_count"] = "XXXXXXXXXXXXX"
-                re["logical-compiled"]["num_t_factories"] = d["re_physical_num_t_factories"]
+                
+                # TODO: not reporting logical-compiled as of 2025-01-09 as we are missing the REQUIRED t_count field.
+                # re["logical-compiled"] = {} # object is optional.
+                # re["logical-compiled"]["logical_architecture_description"] = d["re_logical_architecture_description"]
+                # re["logical-compiled"]["num_qubits"] = d["re_logical_compiled_num_qubits"]
+                # re["logical-compiled"]["t_count"] = "XXXXXXXXXXXXX"
+                # re["logical-compiled"]["num_t_factories"] = d["re_physical_num_t_factories"]
                 # re["logical-compiled"]["gate_count"] # SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["logical-compiled"]["clifford_count"] # SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["logical-compiled"]["circuit_depth"] # SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["logical-compiled"]["t_depth"] # SCHEMA-OPTIONAL.  Not reported at this time.
-                re["physical"] = {} # object is optional
-                re["physical"]["physical_architecture_description"] = d["re_physical_architecture_description"]
-                re["physical"]["code_name"] = d["re_physical_code_name"] #schema enum to "surface" or "other"
-                re["physical"]["code_distance"] = d["re_physical_code_distance"]
-                re["physical"]["runtime"] = d["re_physical_runtime"]
-                re["physical"]["num_qubits"] = d["re_physical_num_qubits"]
-                re["physical"]["t_count"] = "XXXXXXXXXXXXX"
-                re["physical"]["num_t_factories"] = d["re_physical_num_t_factories"]
+                
+                # TODO: not reporting physical as of 2025-01-09 as we are missing the REQUIRED t_count field.
+                # re["physical"] = {} # object is optional
+                # re["physical"]["physical_architecture_description"] = d["re_physical_architecture_description"]
+                # re["physical"]["code_name"] = d["re_physical_code_name"] #schema enum to "surface" or "other"
+                # re["physical"]["code_distance"] = d["re_physical_code_distance"]
+                # re["physical"]["runtime"] = d["re_physical_runtime"]
+                # re["physical"]["num_qubits"] = d["re_physical_num_qubits"]
+                # re["physical"]["t_count"] = "XXXXXXXXXXXXX"
+                # re["physical"]["num_t_factories"] = d["re_physical_num_t_factories"]
                 # re["physical"]["num_factory_qubits"]# SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["physical"]["gate_count"]# SCHEMA-OPTIONAL.  Not reported at this time.
                 # re["physical"]["circuit_depth"]# SCHEMA-OPTIONAL.  Not reported at this time.


### PR DESCRIPTION
not reporting on logical-compiled and physical because we are missing the REQUIRED `t_count` value for each object.