### PR TITLE
Support for Toffoli PREs

### DIFF
--- a/schemas/solution.schema.0.0.1.json
+++ b/schemas/solution.schema.0.0.1.json
@@ -160,7 +160,13 @@
                                     },
                                     "num_T_gates_per_shot": {
                                         "title": "Number of T-Gates",
-                                        "description": "The total number of T-gates used by the solver.",
+                                        "description": "The total number of T-gates used by the solver per shot.",
+                                        "type": "integer",
+                                        "minimum": 0
+                                    },
+                                    "num_toffoli_gates_per_shot": {
+                                        "title": "Number of T-Gates",
+                                        "description": "The total number of Toffoli gates used by the solver per shot.",
                                         "type": "integer",
                                         "minimum": 0
                                     },

--- a/scripts/compute_all_PREs_script.py
+++ b/scripts/compute_all_PREs_script.py
@@ -86,6 +86,16 @@ def get_pqre(solution_lre: dict, config: dict) -> dict[str, Any]:
     solution_pre["solution_data"] = []
     for task_solution in solution_data:
         logging.info(f"Analyzing task {task_solution['task_uuid']}...")
+        num_T_gates = (
+            task_solution["quantum_resources"]["logical"]["num_T_gates_per_shot"]
+            if task_solution["quantum_resources"]["logical"].get("num_T_gates_per_shot")
+            else 0
+        )
+        num_toffoli_gates = (
+            task_solution["quantum_resources"]["logical"]["num_toffoli_gates_per_shot"]
+            if task_solution["quantum_resources"]["logical"].get("num_T_gates_per_shot")
+            else 0
+        )
         try:
             physical_resource_estimation_start = datetime.datetime.now()
 
@@ -93,9 +103,7 @@ def get_pqre(solution_lre: dict, config: dict) -> dict[str, Any]:
                 num_logical_qubits=task_solution["quantum_resources"]["logical"][
                     "num_logical_qubits"
                 ],
-                num_T_gates=task_solution["quantum_resources"]["logical"][
-                    "num_T_gates_per_shot"
-                ],
+                num_T_gates=num_T_gates,
                 hardware_failure_tolerance_per_shot=task_solution["quantum_resources"][
                     "logical"
                 ]["hardware_failure_tolerance_per_shot"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,9 @@ packages = find_namespace:
 python_requires = >=3.8
 
 install_requires =
-    pyLIQTR>=1.2.0
-    qualtran==0.2.0
+    attrs>=23.2.0 # See https://github.com/quantumlib/Qualtran/issues/1520
+    pyLIQTR>=1.3.0
+    qualtran==0.4.0
     pyscf
     openfermion
     openfermionpyscf

--- a/tests/qb_gsee_benchmark/test_qre.py
+++ b/tests/qb_gsee_benchmark/test_qre.py
@@ -63,6 +63,6 @@ def test_get_df_qpe_circuit():
         error_tolerance=error_tolerance,
         failure_tolerance=failure_tolerance,
         df_threshold=1e-3,
-        sf_error_threshold=1e-12,
+        sf_threshold=1e-12,
     )
     assert (1 - square_overlap) ** num_shots < failure_tolerance


### PR DESCRIPTION
This PR adds support for costing Toffoli gates to the PRE script as described in #124. LREs that include Toffoli counts should report them under the `quantum_resources.logical.num_toffoli_gates_per_shot` field of each element in `solution_data`. 

Some notes:
* The PRE script will assume the number of Toffolis to be zero if this field is missing, and similarly assume the number of T gates to be zero if `num_T_gates_per_shot` is missing.
* This PR bumps the versions of several dependencies, including qualtran and pyliqtr. So users will need to re-run `pip install`.
* If at some point in the future we want to generate files conforming to the QB-Estimate-Reporting schema from resource estimates with Toffoli counts, we'd need to update `compute_sponsor_json_resource_estimates.py` to handle this case.