### PR TITLE
Add `notebook` package to requirements so that users don't need to in…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     openpyxl
     markdown
     weasyprint
+    notebook
     
 
 


### PR DESCRIPTION
…stall it manually to use the example notebooks.