### PR TITLE
Bumping pyliqtr to 1.3.6

### DIFF
--- a/scripts/compute_all_LREs_script.py
+++ b/scripts/compute_all_LREs_script.py
@@ -34,6 +34,20 @@ from qb_gsee_benchmark.qre import get_df_qpe_circuit
 from qb_gsee_benchmark.utils import retrieve_fcidump_from_sftp
 from qb_gsee_benchmark.utils import iso8601_timestamp
 
+DOUBLE_FACTORIZED_ATTRIBUTES = [
+    "L",
+    "nL",
+    "nXi",
+    "nLXi",
+    "phase_gradient_eps",
+    "energy_error",
+    "step_error",
+    "bits_rot_givens",
+    "keep_bitsize",
+    "keep_bitsize_outer",
+    "outer_prep_eps",
+    "alpha",
+]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -160,6 +174,7 @@ def get_lqre(
             ).total_seconds()
             logging.info(f"Resource estimation time (seconds): {LRE_calc_time}")
 
+            block_encoding = circuit._block_encoding
             solution_data.append(
                 {
                     "task_uuid": task["task_uuid"],
@@ -172,6 +187,14 @@ def get_lqre(
                             "num_shots": math.ceil(num_shots),
                             "hardware_failure_tolerance_per_shot": hardware_failure_tolerance_per_shot,
                         }
+                    },
+                    "solution_details": {
+                        "block_encoding_details": {
+                            attribute: getattr(block_encoding, attribute)
+                            for attribute in DOUBLE_FACTORIZED_ATTRIBUTES
+                        },
+                        "overlap": overlap,
+                        "num_bits_precision_qpe": circuit._prec,
                     },
                     "run_time": {
                         "preprocessing_time": {
@@ -192,7 +215,6 @@ def get_lqre(
                 }
             )
 
-    
     solver_details = {
         "solver_uuid": config["solver_uuid"],
         "solver_short_name": "DF_QPE",
@@ -225,6 +247,7 @@ def get_lqre(
 
     return results
 
+
 def get_solved_problem_uuids(config: dict[str, Any], output_dir: str) -> set[str]:
     existing_output_files = os.listdir(args.output_dir)
     print(output_dir)
@@ -256,6 +279,7 @@ def get_solved_problem_uuids(config: dict[str, Any], output_dir: str) -> set[str
         f"found {len(solved_problem_uuids)} existing solutions for this solver."
     )
     return set(solved_problem_uuids)
+
 
 def main(args: argparse.Namespace) -> None:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.8
 
 install_requires =
     attrs>=23.2.0 # See https://github.com/quantumlib/Qualtran/issues/1520
-    pyLIQTR>=1.3.0,<1.3.5 # See https://github.com/isi-usc-edu/pyLIQTR/issues/42
+    pyLIQTR>=1.3.6
     qualtran==0.4.0
     pyscf
     openfermion

--- a/src/qb_gsee_benchmark/qre.py
+++ b/src/qb_gsee_benchmark/qre.py
@@ -55,7 +55,7 @@ def get_num_shots(square_overlap: float, failure_tolerance: float):
 
 def get_failure_tolerance_per_shot(
     failure_tolerance: float, num_shots: int
-) -> tuple[QubitizedPhaseEstimation, int, float]:
+) -> float:
     """Get the allowable failure rate per shot.
 
     Generalizes Eq. 18 in arXiv:2406.06335v1 to consider any failure mode.
@@ -77,7 +77,7 @@ def get_df_qpe_circuit(
     failure_tolerance: float,
     sf_threshold: float,
     df_threshold: float,
-):
+)-> tuple[QubitizedPhaseEstimation, int, float]:
     """Get the QPE circuit for a given PySCF FCI object.
 
     This uses an algorithm performance model based on that described in


### PR DESCRIPTION
This PR sets the minimum version of pyliqtr to 1.3.6, the lowest version that includes the fix for the one-norm calculation (see #35). Note that if you already have qb-gsee-benchmark installed, you will need to re-run `pip install` in order to make sure you get the new version of pyliqtr.

Note that the change in the one-norm calculation doesn't seem to have much impact on the resource estimates. For example, for planted solution 1, the one-norm changed by 0.3%. This had no effect on the resource estimate because this difference was not enough to cause the number of phase estimation bits of precision to change.

This PR also records some intermediate data from the circuit generation to the LRE solution file, and fixes some type hints.