### PR TITLE
Update coarse set and catalyst instances so that only instances where…

### DIFF
--- a/problem_instances/problem_instance.benzene.f377cc27-366a-45af-b45a-c8478e4b6199.json
+++ b/problem_instances/problem_instance.benzene.f377cc27-366a-45af-b45a-c8478e4b6199.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-11-20T00:00:00.0+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.873221+00:00",
     "calendar_due_date": null,
     "status": "in_force",
     "superseded_by": null,
@@ -54,7 +55,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -96,7 +99,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.blue_dimer.dc8bdc56-5ebd-4996-6b81-81b1a06d8c76.json
+++ b/problem_instances/problem_instance.blue_dimer.dc8bdc56-5ebd-4996-6b81-81b1a06d8c76.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.746411+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -151,13 +152,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2453.383139874957,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.02433247829503012,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -287,13 +285,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2453.722353799089,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.03051324152993481,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -429,13 +424,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2454.500248971286,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.3725829650051142,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -574,7 +566,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -702,13 +696,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2452.705783831708,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.04910340810039335,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -838,13 +829,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2452.785072302863,
+                "reference_energy": -2452.7849399480883,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01519686441347251,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -981,7 +969,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1120,7 +1110,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1248,13 +1240,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2454.21163859541,
+                "reference_energy": -2454.21155683801,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.05218184279071702,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -1384,13 +1373,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2454.563249138352,
+                "reference_energy": -2454.5631186758173,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.02343907830069505,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -1526,13 +1512,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2454.622490265655,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.1765383516274419,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1670,13 +1653,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2454.679201689047,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.1555460101267775,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.cr_dimer.8ed1a800-a4c6-4bff-a6de-cb220554c42f.json
+++ b/problem_instances/problem_instance.cr_dimer.8ed1a800-a4c6-4bff-a6de-cb220554c42f.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-11-20T00:00:00.0+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.874070+00:00",
     "calendar_due_date": null,
     "status": "in_force",
     "superseded_by": null,
@@ -44,8 +45,10 @@
                 "time_limit_seconds": 172800,
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
-                "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy": -114.40509585988897,
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -78,7 +81,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -111,7 +116,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -144,7 +151,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -177,7 +186,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -209,13 +220,10 @@
                 "time_limit_seconds": 172800,
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
-                "reference_energy": -470.7185128567409,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.6130541128628579,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -248,7 +256,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -281,7 +291,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -313,13 +325,10 @@
                 "time_limit_seconds": 172800,
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
-                "reference_energy": -156.7739602011705,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.001746224484355911,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -352,7 +361,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -385,7 +396,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -418,7 +431,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.fe_red.a8895776-3583-4884-fbc7-d6f9df21a7ac.json
+++ b/problem_instances/problem_instance.fe_red.a8895776-3583-4884-fbc7-d6f9df21a7ac.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.775024+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -111,13 +112,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.687414514583,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.1351069374313412,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -210,13 +208,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.816535546089,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.5971537341314614,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -311,13 +306,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.878328984242,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.5423147387322333,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -405,13 +397,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.707486407847,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.2931065608763305,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -504,13 +493,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.825891046245,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.2025065279660474,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -605,13 +591,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.848378223888,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.8911620197292276,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -699,13 +682,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.788336147052,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.1497979623848037,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -799,7 +779,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -894,13 +876,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2592.911124291167,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.6127077584318205,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.mn_mono.cb40f3f7-ffe8-40e8-4544-f26aad5a8bd8.json
+++ b/problem_instances/problem_instance.mn_mono.cb40f3f7-ffe8-40e8-4544-f26aad5a8bd8.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.788176+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -126,13 +127,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1321.593612370238,
+                "reference_energy": -1321.5935398046663,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.003189041808771883,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -237,13 +235,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.107039844683,
+                "reference_energy": -1322.106943845381,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01848453038429909,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -346,13 +341,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.582234109127,
+                "reference_energy": -1322.5821398164346,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.04804661015269527,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -457,13 +449,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.661962118007,
+                "reference_energy": -1322.6616472458961,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.0245938485100663,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -566,13 +555,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.594438035404,
+                "reference_energy": -1322.594310998134,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.02843419017733956,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -677,13 +663,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.651998080473,
+                "reference_energy": -1322.6518906234996,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.03204475191489623,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -786,13 +769,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.55739550674,
+                "reference_energy": -1322.5572518303957,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.02755012857708406,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -897,13 +877,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1322.65692896071,
+                "reference_energy": -1322.6568579096988,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01334577522488482,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.mo2_n2.90d4e4fc-1216-4846-b45f-198c0530e29b.json
+++ b/problem_instances/problem_instance.mo2_n2.90d4e4fc-1216-4846-b45f-198c0530e29b.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.847796+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -234,13 +235,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -4269.911340904,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.194978937402,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with unchanged orbital ordering. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -451,13 +449,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -4269.95022854353,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.756735396441,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with unchanged orbital ordering. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -668,13 +663,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -4269.91981972922,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.689774744874,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with unchanged orbital ordering. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.mo_n2.664ec8e4-09d5-41cc-6266-ddb26219366f.json
+++ b/problem_instances/problem_instance.mo_n2.664ec8e4-09d5-41cc-6266-ddb26219366f.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.843800+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -345,13 +346,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -4800.64948758995,
+                "reference_energy": -4800.649257689289,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.017246667863,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -412,7 +410,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -472,13 +472,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1647.3491358097,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.734050695969,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -800,13 +797,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -4800.62572354644,
+                "reference_energy": -4800.625484800499,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.021982675909,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.mo_n2_pincer.8a3787cc-d3d0-42a8-d9a9-7de2aed45208.json
+++ b/problem_instances/problem_instance.mo_n2_pincer.8a3787cc-d3d0-42a8-d9a9-7de2aed45208.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.799462+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -161,13 +162,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.53386390964,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.779005590646,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -310,7 +308,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -449,7 +449,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -592,7 +594,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -730,13 +734,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.27122973346,
+                "reference_energy": -2928.271057328722,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.00988973138,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -878,13 +879,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.30539273947,
+                "reference_energy": -2928.3048382131465,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.051312006526,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -1022,13 +1020,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.43351150221,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.346462214719,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1171,7 +1166,9 @@
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1309,13 +1306,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.21304660173,
+                "reference_energy": -2928.212812739105,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01572955311,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -1457,13 +1451,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.2646178975,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.041415756161,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1601,13 +1592,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.27989772549,
+                "reference_energy": -2928.279700803864,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.016852540238,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -1749,13 +1737,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.31225576851,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.094385585174,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -1893,13 +1878,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.30960854932,
+                "reference_energy": -2928.3093587929616,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.024577394921,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -2041,13 +2023,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2928.34631056936,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.161187935897,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -2171,13 +2150,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2623.09863495122,
+                "reference_energy": -2623.09858046366,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.022559078142,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -2305,13 +2281,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2623.16661546777,
+                "reference_energy": -2623.166452810864,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.017046611936,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.ozone.9560107e-f1ad-4480-aa51-ef03edda6e19.json
+++ b/problem_instances/problem_instance.ozone.9560107e-f1ad-4480-aa51-ef03edda6e19.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-11-20T00:00:00.0+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.884409+00:00",
     "calendar_due_date": null,
     "status": "in_force",
     "superseded_by": null,
@@ -45,7 +46,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -77,13 +80,10 @@
                 "time_limit_seconds": 172800,
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
-                "reference_energy": -221.57897267925446,
+                "reference_energy": -221.5782081441198,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.707209581446,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -116,7 +116,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -149,7 +151,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -181,13 +185,10 @@
                 "time_limit_seconds": 172800,
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
-                "reference_energy": -221.55895092155683,
+                "reference_energy": -221.55896879498385,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.030277540098,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -220,7 +221,9 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.ru_macho.b78a10f2-ce8a-43c0-69ec-4cf666d8e85c.json
+++ b/problem_instances/problem_instance.ru_macho.b78a10f2-ce8a-43c0-69ec-4cf666d8e85c.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.852995+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -63,13 +64,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -187.721413991188,
+                "reference_energy": -187.72141980373365,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01830587056390337,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -123,13 +121,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -380.9018801594908,
+                "reference_energy": -380.901861517385,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.09164286739089147,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -183,13 +178,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -380.8881748288609,
+                "reference_energy": -380.88806185799865,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.07562428427179291,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -297,13 +289,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2021.175594529969,
+                "reference_energy": -2021.1755907881034,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01166686437303779,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -419,13 +408,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2021.356651702967,
+                "reference_energy": -2021.3561470840154,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.05534781287816805,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -542,13 +528,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2208.990491372022,
+                "reference_energy": -2208.9903674400903,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.07163538789399929,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -673,13 +656,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2209.163580420163,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.06127282648169622,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -806,13 +786,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2402.040506564869,
+                "reference_energy": -2402.040424337404,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.01487905299500883,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -947,13 +924,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -2402.219494504201,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.09802672778684904,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {

--- a/problem_instances/problem_instance.ru_mono.7213642b-5f16-48be-d5e5-2bc42ebb8526.json
+++ b/problem_instances/problem_instance.ru_mono.7213642b-5f16-48be-d5e5-2bc42ebb8526.json
@@ -4,6 +4,7 @@
     "problem_type": "GSEE",
     "application_domain": "QC",
     "creation_timestamp": "2024-03-20T20:48:21.795324+00:00",
+    "latest_update_timestamp": "2025-01-23T21:44:34.865528+00:00",
     "calendar_due_date": "2124-03-20T20:48:21.795324+00:00",
     "status": "in_force",
     "superseded_by": null,
@@ -132,13 +133,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1722.886930507167,
+                "reference_energy": -1722.8869287351336,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.00141571459231899,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -249,13 +247,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1723.022656367642,
+                "reference_energy": null,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.3283422985373298,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "None",
+                "reference_energy_method": "None"
             },
             "supporting_files": [
                 {
@@ -365,13 +360,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1796.945217268863,
+                "reference_energy": -1796.9450583076534,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.07771956705264206,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -485,13 +477,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1797.371453350987,
+                "reference_energy": -1797.3705440236513,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 0.1065915164182868,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Forward schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -600,13 +589,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": -1723.455357141506,
+                "reference_energy": -1723.4553571317356,
                 "reference_energy_units": "Hartree",
-                "reference_energy_uncertainty": 1.762651759865861e-05,
-                "reference_energy_uncertainty_units": "millihartree",
-                "reference_energy_source": "Calculated with Block2 (https://block2.readthedocs.io/)",
-                "reference_energy_method": "DMRG with linear extrapolation to zero discarded weight. Reverse schedule used with orbital ordering based on genetic algorithm optimization with the exchange matrix. See DRMG section of arXiv:2406.06335.",
-                "reference_energy_uncertainty_type": "value +/- uncertainty gives a 95% confidence interval. The uncertainty is from the fit."
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {
@@ -724,8 +710,10 @@
                 "absolute_accuracy_threshold": 0.00159362,
                 "absolute_accuracy_threshold_energy_units": "Hartree",
                 "energy_target": 0.99,
-                "reference_energy": null,
-                "reference_energy_units": "Hartree"
+                "reference_energy": -1723.5221738785401,
+                "reference_energy_units": "Hartree",
+                "reference_energy_source": "Benchmark Host Calculations, SHCI and DMRG; average of two values within 0.1 mHa",
+                "reference_energy_method": "SHCI and extrapolated DMRG"
             },
             "supporting_files": [
                 {


### PR DESCRIPTION
… DMRG and SHCI agree to within 0.5mHa have reference energies, the rest are nulled.

Matt's latest solutions, as in PR #160 taken into account.

All instances pass json validation.